### PR TITLE
Better error message when target dir for locales does not exist

### DIFF
--- a/features/localeapp_binary.feature
+++ b/features/localeapp_binary.feature
@@ -99,6 +99,16 @@ Feature: localeapp executable
     And help should not be displayed
     And a file named "config/locales/en.yml" should exist
 
+  Scenario: Running pull without having a locales dir
+    In order to retreive my translations
+    Given I have a translations on localeapp.com for the project with api key "MYAPIKEY"
+    And an initializer file
+    When I run `localeapp pull`
+    Then the output should contain:
+    """
+    Could not write locale file, please make sure that config/locales exists and is writeable
+    """
+
   Scenario: Running push on a file
     In order to send my translations
     When I have a valid project on localeapp.com with api key "MYAPIKEY"

--- a/lib/localeapp/updater.rb
+++ b/lib/localeapp/updater.rb
@@ -57,6 +57,11 @@ module Localeapp
 
     # originally from ActiveSupport
     def atomic_write(file_name, temp_dir = Dir.tmpdir)
+      target_dir = File.dirname(file_name)
+      unless Dir.exists?(target_dir)
+        raise "Could not write locale file, please make sure that #{target_dir} exists and is writeable"
+      end
+
       temp_file = Tempfile.new(File.basename(file_name), temp_dir)
       yield temp_file
       temp_file.close


### PR DESCRIPTION
Hi there,

in our most recent project we use localeapp to completely handle the translations. We decided to kick out the locale dir from our repo and just use the localeapp files (while gitignored) which works very well.

Unfortunately when you do a deploy, there will be no config/locales dir and `localeapp pull` will fail with a non-descriptive error message due to the failing `FileUtils.mv` in updater.rb

Granted, it's an edge case, but on the other hand I think it's fine to have a clearer error message what could be wrong instead of having to search through the code.

Or it's just me, being to dumb to unterstand the error message in first place ;-)

Greetings,
- Robin
