### PR TITLE
Ignore HUP in bin/locale

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -125,8 +125,10 @@ command :daemon do |c|
 
       STDOUT.reopen(File.open(Localeapp.configuration.daemon_log_file, 'a'))
       pid = fork do
+        Signal.trap('HUP', 'IGNORE')
         command.call
       end
+      Process.detach(pid)
 
       File.open(Localeapp.configuration.daemon_pid_file, 'w') {|f| f << pid}
     else


### PR DESCRIPTION
Hi guys,

I was integrating localeapp to the application I am currently working on. While I was starting the daemon mode on staging with capistrano I figured out, that it should survive the HUP command, which is send when logging out.

I haven't found any tests for the daemon feature and, since it is a minor change in the binary thing, I hope it doesn't matter. I tried it out locally, works like a charme for me.. :)

Thanks for your localeapp service!

Bye, Joe
