### PR TITLE
make sure psych was fully loaded by checking for Psych::VERSION

### DIFF
--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -111,7 +111,7 @@ module Localeapp
     end
 
     def load_yaml(contents)
-      if defined? Psych
+      if defined?(Psych) && defined?(Psych::VERSION)
         Psych.load(contents)
       else
         normalize_results(YAML.load(contents))


### PR DESCRIPTION
Hi, this commit should fix ticket #27.

The problem is that under Ruby 1.9.2, if you require `yaml`, the Psych constant will be defined, but the entire library is not loaded.  For example:

```
1.9.2p318 :001 > require 'yaml'
 => true 
1.9.2p318 :002 > defined? Psych
 => "constant" 
1.9.2p318 :003 > Psych.load '--- hello world'
NoMethodError: private method `load' called for Psych:Module
    from (irb):3
    from /Users/aaron/.rvm/rubies/ruby-1.9.2-p318/bin/irb:16:in `<main>'
1.9.2p318 :004 >
```

Because of [the way rails monkeypatches Object](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/dependencies.rb#L293), if you have `active_support/dependencies` loaded, rather than getting a `NoMethodError`, it will attempt to load some ruby file:

```
1.9.2p318 :001 > require 'active_support/dependencies'
 => true 
1.9.2p318 :002 > require 'yaml'
 => true 
1.9.2p318 :003 > defined? Psych
 => "constant" 
1.9.2p318 :004 > Psych.load '--- hello world'
LoadError: no such file to load -- --- hello world
    from /Users/aaron/git/rails/activesupport/lib/active_support/dependencies.rb:243:in `load'
    from /Users/aaron/git/rails/activesupport/lib/active_support/dependencies.rb:243:in `block in load'
    from /Users/aaron/git/rails/activesupport/lib/active_support/dependencies.rb:234:in `load_dependency'
    from /Users/aaron/git/rails/activesupport/lib/active_support/dependencies.rb:243:in `load'
    from (irb):4
    from /Users/aaron/.rvm/rubies/ruby-1.9.2-p318/bin/irb:16:in `<main>'
1.9.2p318 :005 >
```

We can check to ensure that Psych is fully loaded by searching for the `VERSION` constant:

```
1.9.2p318 :001 > require 'active_support/dependencies'
 => true 
1.9.2p318 :002 > require 'yaml'
 => true 
1.9.2p318 :003 > defined?(Psych) && defined?(Psych::VERSION)
 => nil 
1.9.2p318 :004 >
```
