### PR TITLE
Hack/fix for fallback and default

### DIFF
--- a/lib/localeapp/default_value_handler.rb
+++ b/lib/localeapp/default_value_handler.rb
@@ -3,14 +3,16 @@ module I18n::Backend::Base
 
   def default(locale, object, subject, options = {})
     result = default_without_handler(locale, object, subject, options)
+    return result if ::Localeapp.configuration.sending_disabled?
 
     if result
       sender = Localeapp::Sender.new
 
       # Make the default value a complete translation
-      sender.post_translation(locale, object, options, result)
+      sender.post_translation(locale, object || @last_key, options, result)
     end
 
+    @last_key = object
     return result
   end
 end


### PR DESCRIPTION
This may not be the best way to solve this, but it works for us. It's potentially dangerous, but I don't know of any scenarios where object would be nil that it wouldn't have just been called with the correct key.

This also adds in a guard for `sending_disabled?`
