### PR TITLE
GLI 2.0 warning

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency('json')
   s.add_dependency('rest-client')
   s.add_dependency('ya2yaml')
-  s.add_dependency('gli')
+  s.add_dependency('gli', '1.6.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '2.11.0')


### PR DESCRIPTION
Fixes #55. GLI 2.0 dropped on August 14, 2012, and the localeapp gem is not compatible with the new version. The GLI dependency should therefore be locked to the last 1.x version.
