### PR TITLE
Just add defaults to translations to send

### DIFF
--- a/lib/localeapp/default_value_handler.rb
+++ b/lib/localeapp/default_value_handler.rb
@@ -3,15 +3,7 @@ module I18n::Backend::Base
 
   def default(locale, object, subject, options = {})
     result = default_without_handler(locale, object, subject, options)
-    return result if ::Localeapp.configuration.sending_disabled?
-
-    if result
-      sender = Localeapp::Sender.new
-
-      # Make the default value a complete translation
-      sender.post_translation(locale, object, options, result)
-    end
-
+    Localeapp.missing_translations.add(locale, object, subject, options)
     return result
   end
 end

--- a/spec/localeapp/default_value_handler_spec.rb
+++ b/spec/localeapp/default_value_handler_spec.rb
@@ -7,19 +7,10 @@ end
 describe I18n::Backend::Base, '#default' do
   let(:klass) { Klass.new }
 
-  it "posts translations to Locale" do
+  it "adds translations to missing translations to send to Locale" do
     with_configuration(:sending_environments => ['my_env'], :environment_name => 'my_env' ) do
-      sender = Localeapp::Sender.new
-      Localeapp::Sender.should_receive(:new).and_return(sender)
-      sender.should_receive(:post_translation)
-      klass.default('locale', 'object', 'subject')
-    end
-  end
-
-  it "doesn't post when sending is disabled" do
-    with_configuration(:sending_environments => []) do
-      Localeapp::Sender.should_not_receive(:new)
-      klass.default('locale', 'object', 'subject')
+      Localeapp.missing_translations.should_receive(:add).with(:en, 'foo', 'bar', :baz => 'bam')
+      klass.default(:en, 'foo', 'bar', :baz => 'bam')
     end
   end
 end

--- a/spec/localeapp/sender_spec.rb
+++ b/spec/localeapp/sender_spec.rb
@@ -26,27 +26,6 @@ describe Localeapp::Sender, "#post_translation(locale, key, options, value = nil
       :method => :post)).and_return(double('response', :code => 200))
     @sender.post_translation('en', 'test.key', { 'foo' => 'foo', 'bar' => 'bar', :default => 'default', :scope => 'scope' }, 'test content')
   end
-
-  it "posts default translation data to the backend" do
-    data = {
-      :translation => {
-        :key => 'absolutely.missing',
-        :locale => 'en',
-        :substitutions => ['bar', 'foo'],
-        :description => 'a sensible default'
-      }
-    }
-
-    RestClient::Request.should_receive(:execute).with(hash_including(
-      :url => @sender.translations_url,
-      :payload => data.to_json,
-      :headers => {
-        :x_localeapp_gem_version => Localeapp::VERSION,
-        :content_type => :json },
-      :method => :post)).and_return(double('response', :code => 200))
-
-    I18n.t('absolutely.missing', { 'foo' => 'foo', 'bar' => 'bar', :default => 'a sensible default' })
-  end
 end
 
 describe Localeapp::Sender, "#post_missing_translations" do


### PR DESCRIPTION
Sending each one individually is really, really slow if there are many on a page
