### PR TITLE
Fix bug when :default is an array

### DIFF
--- a/lib/localeapp/default_value_handler.rb
+++ b/lib/localeapp/default_value_handler.rb
@@ -3,7 +3,12 @@ module I18n::Backend::Base
 
   def default(locale, object, subject, options = {})
     result = default_without_handler(locale, object, subject, options)
-    Localeapp.missing_translations.add(locale, object, subject, options)
+    case subject # case is what i18n gem uses here so doing the same
+    when Array
+      Localeapp.missing_translations.add(locale, object, result, options)
+    else
+      Localeapp.missing_translations.add(locale, object, subject, options)
+    end
     return result
   end
 end

--- a/spec/localeapp/default_value_handler_spec.rb
+++ b/spec/localeapp/default_value_handler_spec.rb
@@ -13,4 +13,20 @@ describe I18n::Backend::Base, '#default' do
       klass.default(:en, 'foo', 'bar', :baz => 'bam')
     end
   end
+
+  describe "when subject is an array" do
+    it "uses result of default call instead of array" do
+      with_configuration(:sending_environments => ['my_env'], :environment_name => 'my_env' ) do
+        Localeapp.missing_translations.should_receive(:add).with(:en, 'foo', 'not missing', :baz => 'bam')
+        I18n.stub!(:translate) do |subject, _|
+          if subject == :not_missing
+            "not missing"
+          else
+            nil
+          end
+        end
+        klass.default(:en, 'foo', [:missing, :not_missing], :baz => 'bam')
+      end
+    end
+  end
 end


### PR DESCRIPTION
We we're sending the entire array. i18n gem uses this array to lookup
other keys for content so we should be using the return value from that
as the default
