### PR TITLE
rack should be a regular dependency, not a development dependency

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n')
   s.add_dependency('json')
   s.add_dependency('rest-client')
+  s.add_dependency('rack')
   s.add_dependency('ya2yaml')
   s.add_dependency('gli')
 
   s.add_development_dependency('rake')
-  s.add_development_dependency('rack')
   s.add_development_dependency('rspec', '2.11.0')
   s.add_development_dependency('yard', '0.6.7')
   s.add_development_dependency('RedCloth', '4.2.9')


### PR DESCRIPTION
Hi,

I'm using localeapp in a project which does not include rack.

`bundle exec localeapp --help` fails with the following error:

```
/Users/martin/.gem/gems/localeapp-0.6.9/lib/localeapp/routes.rb:1:in `require': cannot load such file -- rack/utils (LoadError)
    from /Users/martin/.gem/gems/localeapp-0.6.9/lib/localeapp/routes.rb:1:in `<top (required)>'
    from /Users/martin/.gem/gems/localeapp-0.6.9/lib/localeapp.rb:28:in `require'
    from /Users/martin/.gem/gems/localeapp-0.6.9/lib/localeapp.rb:28:in `<top (required)>'
    from /Users/martin/.gem/gems/localeapp-0.6.9/bin/localeapp:4:in `require'
    from /Users/martin/.gem/gems/localeapp-0.6.9/bin/localeapp:4:in `<top (required)>'
    from /Users/martin/.gem/bin/localeapp:23:in `load'
    from /Users/martin/.gem/bin/localeapp:23:in `<main>'
```

This pull request fixes the problem.
