### PR TITLE
Safely create synchronization data file

### DIFF
--- a/lib/localeapp/rails.rb
+++ b/lib/localeapp/rails.rb
@@ -36,8 +36,10 @@ module Localeapp
     end
 
     def self.initialize_synchronization_data_file
-      if !File.exists?(Localeapp.configuration.synchronization_data_file)
-        File.open(Localeapp.configuration.synchronization_data_file, 'w') do |f|
+      sync_file = Localeapp.configuration.synchronization_data_file
+      if !File.exists?(sync_file)
+        Dir.mkdir(File.dirname(sync_file))
+        File.open(sync_file, 'w') do |f|
           f.write({:polled_at => Time.now.to_i, :updated_at => Time.now.to_i}.to_yaml)
         end
       end


### PR DESCRIPTION
In our setup, Rails has no occasion to touch `log/test.log` or similar files which also creates the log directory.

This PR will ensure the full hierarchy exists when touching the `log/localeapp.yml` file.
