### PR TITLE
Push default translations only into default locale

### DIFF
--- a/lib/localeapp/missing_translations.rb
+++ b/lib/localeapp/missing_translations.rb
@@ -7,8 +7,12 @@ module Localeapp
     end
 
     def add(locale, key, description = nil, options = {})
-      record = MissingTranslationRecord.new(key, locale, description, options)
-      @translations[I18n.default_locale][key] = record
+      begin
+        I18n.t!(key, locale: I18n.default_locale, default: [])
+      rescue I18n::MissingTranslationData
+        record = MissingTranslationRecord.new(key, locale, description, options)
+        @translations[I18n.default_locale][key] = record
+      end
     end
 
     def [](locale)


### PR DESCRIPTION
When sending a missing translation request via the API, only the default locale should be updated with the default translation value regardless of the user's current locale.

This will prevent locales marked for outside translation from being marked as complete.
