### PR TITLE
extend the exception handler do not replace it

### DIFF
--- a/lib/localeapp/exception_handler.rb
+++ b/lib/localeapp/exception_handler.rb
@@ -1,22 +1,26 @@
 module Localeapp
-  class ExceptionHandler
-    def self.call(exception, locale, key, options)
+  module ExceptionHandler
+    def call(exception, locale, key, options)
       Localeapp.log(exception.message)
+
       # Which exact exception is set up by our i18n shims
       if exception.is_a? Localeapp::I18nMissingTranslationException
         Localeapp.log("Detected missing translation for key(s) #{key.inspect}")
 
-        [*key].each do |key|
-          Localeapp.missing_translations.add(locale, key, nil, options || {})
+        [*key].each do |k|
+          Localeapp.missing_translations.add(locale, k, nil, options || {})
         end
 
-        [locale, key].join(', ')
+        super
       else
-        Localeapp.log('Raising exception')
-        raise
+        super
       end
     end
   end
 end
 
-I18n.exception_handler = Localeapp::ExceptionHandler
+module I18n
+  class ExceptionHandler
+    include Localeapp::ExceptionHandler
+  end
+end

--- a/spec/localeapp/exception_handler_spec.rb
+++ b/spec/localeapp/exception_handler_spec.rb
@@ -19,10 +19,18 @@ describe Localeapp::ExceptionHandler, '#call(exception, locale, key, options)' d
     I18n.t(['foo', 'bar'])
   end
 
+  it "delegates to super for handling of output" do
+    expect(I18n.t('foo', rescue_format: :html)).to eq("translation missing: foo")
+  end
+
+  it "delegates to super for handling of rescue_format" do
+    expect(I18n.t('foo', rescue_format: :html)).to eq("<span class=\"translation_missing\" title=\"translation missing: en.foo\">Foo</span>")
+  end
+
   it "handles missing translation exception" do
     expect {
       exception = Localeapp::I18nMissingTranslationException.new(:en, 'foo', {})
-      Localeapp::ExceptionHandler.call(exception, :en, 'foo', {})
+      Localeapp::ExceptionHandler.new.call(exception, :en, 'foo', {})
     }.to_not raise_error
   end
 end


### PR DESCRIPTION
Replacing the exception handler circumvents the work that Rails
ActionView::Helpers::TranslationHelper does to wrap missing translations
in a span.
