### PR TITLE
Fixes #105. Throw Localeapp::MissingApiKey if an API key has not been se...

### DIFF
--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -56,6 +56,7 @@ module Localeapp
 
   class LocaleappError < StandardError; end
   class PotentiallyInsecureYaml < LocaleappError; end
+  class MissingApiKey < LocaleappError; end
 
   class << self
     # An Localeapp configuration object.

--- a/lib/localeapp/rails/controller.rb
+++ b/lib/localeapp/rails/controller.rb
@@ -7,6 +7,7 @@ module Localeapp
       end
 
       def handle_translation_updates
+        raise Localeapp::MissingApiKey unless ::Localeapp.configuration.api_key
         unless ::Localeapp.configuration.polling_disabled?
           ::Localeapp.log_with_time 'Handling translation updates'
           if ::Localeapp.poller.needs_polling?

--- a/spec/localeapp/rails/controller_spec.rb
+++ b/spec/localeapp/rails/controller_spec.rb
@@ -12,7 +12,11 @@ require 'localeapp/rails/controller'
 describe Localeapp::Rails::Controller, '#handle_translation_updates' do
   before do
     TestController.send(:include, Localeapp::Rails::Controller)
-    with_configuration(:synchronization_data_file => LocaleappSynchronizationData::setup) do
+    configuration = {
+      :synchronization_data_file => LocaleappSynchronizationData::setup,
+      :api_key => "my_key"
+    }
+    with_configuration(configuration) do
       @controller = TestController.new
     end
   end
@@ -87,6 +91,16 @@ describe Localeapp::Rails::Controller, '#handle_translation_updates' do
     it "doesn't call I18n.relaod! when the synchronization file's updated_at is the same" do
       I18n.should_not_receive(:reload!)
       @controller.handle_translation_updates
+    end
+  end
+
+  context "when an api_key is missing" do
+    before do
+      Localeapp.configuration.api_key = nil
+    end
+
+    it "raises an exception" do
+      expect { @controller.handle_translation_updates }.to raise_error Localeapp::MissingApiKey
     end
   end
 end


### PR DESCRIPTION
...t. This prevents an error which could otherwise appear only in a production environment.
