### PR TITLE
Fix error when you have wrapped defaults in Rails 4

### DIFF
--- a/lib/localeapp/default_value_handler.rb
+++ b/lib/localeapp/default_value_handler.rb
@@ -4,11 +4,17 @@ module I18n::Backend::Base
   def default(locale, object, subject, options = {})
     result = default_without_handler(locale, object, subject, options)
     case subject # case is what i18n gem uses here so doing the same
-    when Array, Symbol
-      # Do nothing, we only send missing translations with text defaults
-    else
+    when String
       value = locale == I18n.default_locale ? subject : nil
       Localeapp.missing_translations.add(locale, object, value, options)
+    when Array
+      text_default = subject.detect{|item| item.is_a? String }
+      if text_default
+        value = locale == I18n.default_locale ? text_default : nil
+        Localeapp.missing_translations.add(locale, object, value, options)
+      end
+    when Symbol
+      # Do nothing, we only send missing translations with text defaults
     end
     return result
   end

--- a/spec/localeapp/default_value_handler_spec.rb
+++ b/spec/localeapp/default_value_handler_spec.rb
@@ -30,13 +30,25 @@ describe I18n::Backend::Base, '#default' do
   end
 
   describe "when subject is an Array" do
-    it "doesn't send anything to Locale" do
-      allow_sending do
-        Localeapp.missing_translations.should_not_receive(:add)
-        I18n.stub!(:translate) do |subject, _|
-          subject == :not_missing ? "not missing" : nil
+
+    describe "and there is a text inside the array" do
+      it "add translations to missing translations to send to Locale" do
+        allow_sending do
+          Localeapp.missing_translations.should_receive(:add).with(:en, 'foo', 'correct default', :baz => 'bam')
+          klass.default(:en, 'foo', [:missing, 'correct default'], :baz => 'bam')
         end
-        klass.default(:en, 'foo', [:missing, :not_missing], :baz => 'bam')
+      end
+    end
+
+    describe "and there is not a text inside the array" do
+      it "doesn't send anything to Locale" do
+        allow_sending do
+          Localeapp.missing_translations.should_not_receive(:add)
+          I18n.stub!(:translate) do |subject, _|
+            subject == :not_missing ? "not missing" : nil
+          end
+          klass.default(:en, 'foo', [:missing, :not_missing], :baz => 'bam')
+        end
       end
     end
   end


### PR DESCRIPTION
Hi guys,

We're using Localeapp in a Rails 4 app and we're having a problem when we use defaults, because Rails wraps the strings inside an array and Localeapp gem is simply ignoring arrays. This looks wrong. I believe Localeapp should consider arrays when they have a valid text inside and send the key for translations with that text as the default. So heres a PR for that. If you can merge it ASAP we will appreciate so we don't need to point to my repo in our project.
