### PR TITLE
Use mkdir_p so app can start if log dir already exists

### DIFF
--- a/lib/localeapp/rails.rb
+++ b/lib/localeapp/rails.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Localeapp
   module Rails
     def self.initialize
@@ -38,7 +40,7 @@ module Localeapp
     def self.initialize_synchronization_data_file
       sync_file = Localeapp.configuration.synchronization_data_file
       if !File.exists?(sync_file)
-        Dir.mkdir(File.dirname(sync_file))
+        FileUtils.mkdir_p(File.dirname(sync_file))
         File.open(sync_file, 'w') do |f|
           f.write({:polled_at => Time.now.to_i, :updated_at => Time.now.to_i}.to_yaml)
         end


### PR DESCRIPTION
The way it was, if the log dir existed but localeapp.yml did not, the app would blow up:

```
Errno::EEXIST: File exists - /home/deploy/buildAgent/work/8823f7f94dd0e3f9/log
```
