### PR TITLE
Respect I18n `scope` option when constructing a translation key

### DIFF
--- a/lib/localeapp/missing_translations.rb
+++ b/lib/localeapp/missing_translations.rb
@@ -13,6 +13,9 @@ module Localeapp
     end
 
     def add(locale, key, description = nil, options = {})
+      separator = options.delete(:separator) { I18n.default_separator }
+      scope = options.delete(:scope)
+      key = I18n.normalize_keys(nil, key, scope, separator).map(&:to_s).join(separator)
       record = MissingTranslationRecord.new(key, locale, description, options)
       @translations[locale][key] = record
     end

--- a/spec/localeapp/missing_translations_spec.rb
+++ b/spec/localeapp/missing_translations_spec.rb
@@ -9,6 +9,14 @@ describe Localeapp::MissingTranslations, "#add(locale, key, description = nil, o
     translations[:en]['foo'].description.should == 'bar'
     translations[:en]['foo'].options.should == { :baz => 'bam' }
   end
+
+  it "respects I18n options when constructing a key" do
+    translations = Localeapp::MissingTranslations.new
+    translations.add(:en, 'foo', nil, { :scope => 'bar', :baz => 'bam' })
+
+    translations[:en].should include('bar.foo')
+    translations[:en]['bar.foo'].options.should == { :baz => 'bam' }
+  end
 end
 
 describe Localeapp::MissingTranslations, "#to_send" do


### PR DESCRIPTION
Fixes #116.
