### PR TITLE
Fixes install --github so it append README.md

### DIFF
--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -206,14 +206,15 @@ CONTENT
 
         def create_gitignore
           File.open('.gitignore', 'a+') do |file|
-            file.write config_dir
+            file.write "\n#{config_dir}"
           end
         end
 
         def create_readme
-          File.open('README.md', 'w+') do |file|
+          File.open('README.md', 'a+') do |file|
             file.write <<-CONTENT
-# #{project_data['name']}
+
+---
 
 A ruby translation project managed on [Locale](http://www.localeapp.com/) that's open to all!
 


### PR DESCRIPTION
- [x] Before it replaced the `README.md` file with new content running `localeapp install --github <KEY>`, now it append content in a more proper manner. If no `README.md` exists its still created.
- [x] `.localeapp` are sometimes injected without space on the previous `.gitignore` key, now it ensure prefix with newline.
