### PR TITLE
Tweak Aruba config for jRuby.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Gemfile.*.lock
 .yardoc/*
 doc/*
 tmp/*
+.ruby-version
+.ruby-gemsets

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--color
 -I ./lib
 -I ./spec

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,6 @@
 require 'aruba/cucumber'
+require 'aruba/jruby'
+
 require File.expand_path(File.join(File.dirname(__FILE__), '../../spec/support/localeapp_integration_data'))
 World(LocaleappIntegrationData)
 
@@ -18,4 +20,3 @@ module FakeWebHelper
   end
 end
 World(FakeWebHelper)
-

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,4 +1,11 @@
 Before do
   ENV['FAKE_WEB_DURING_CUCUMBER_RUN'] = '1'
-  @aruba_timeout_seconds = 15
+  @aruba_timeout_seconds = RUBY_PLATFORM == 'java' ? 60 : 15
+end
+
+# Globally @announce-cmd to track down slow cmd.
+Aruba.configure do |config|
+  config.before_cmd do |cmd|
+    puts "$ '#{cmd}'"
+  end
 end


### PR DESCRIPTION
Tested with `jruby-1.7.9`, also add global `@announce-cmd` because it can be tweaked to run quicker without `cmd` spawning a new Ruby process. See: https://github.com/cucumber/aruba#testing-ruby-cli-programs-without-spawning-a-new-ruby-process
