### PR TITLE
Config option to blacklist request paths (such as /admin)

### DIFF
--- a/lib/localeapp/configuration.rb
+++ b/lib/localeapp/configuration.rb
@@ -84,6 +84,12 @@ module Localeapp
     # default: nil
     attr_accessor :blacklisted_keys_pattern
 
+    # A regular expression that is matched against the request path.
+    # If the request path matches, the missing translations will not be sent
+    # to the Locale server via the rails exception handler.
+    # default: nil
+    attr_accessor :blacklisted_request_paths_pattern
+
     def initialize
       defaults.each do |setting, value|
         send("#{setting}=", value)
@@ -127,6 +133,11 @@ module Localeapp
 
     def has_api_key?
       !api_key.nil? && !api_key.empty?
+    end
+
+    def request_path_blacklisted?(request_path)
+      return false unless blacklisted_request_paths_pattern
+      request_path.match(blacklisted_request_paths_pattern)
     end
 
   end

--- a/lib/localeapp/rails/controller.rb
+++ b/lib/localeapp/rails/controller.rb
@@ -26,7 +26,8 @@ module Localeapp
       end
 
       def send_missing_translations
-        return if ::Localeapp.configuration.sending_disabled?
+        return if ::Localeapp.configuration.sending_disabled? ||
+                  ::Localeapp.configuration.request_path_blacklisted?(request.path)
         ::Localeapp.missing_translations.reject_blacklisted
         ::Localeapp.sender.post_missing_translations
       end

--- a/spec/localeapp/configuration_spec.rb
+++ b/spec/localeapp/configuration_spec.rb
@@ -85,8 +85,12 @@ describe Localeapp::Configuration do
     expect { configuration.daemon_log_file = 'log/la.log' }.to change(configuration, :daemon_log_file).to('log/la.log')
   end
 
-  it "sets the sending_blacklist by default" do
+  it "sets the keys sending_blacklist by default" do
     expect(configuration.blacklisted_keys_pattern).to be_nil
+  end
+
+  it "sets the request paths sending_blacklist by default" do
+    expect(configuration.blacklisted_request_paths_pattern).to be_nil
   end
 
   context "enabled_sending_environments" do

--- a/spec/localeapp/rails/controller_spec.rb
+++ b/spec/localeapp/rails/controller_spec.rb
@@ -123,6 +123,7 @@ describe Localeapp::Rails::Controller, '#send_missing_translations' do
     end
     TestController.send(:include, Localeapp::Rails::Controller)
     @controller = TestController.new
+    @controller.stub_chain(:request, :path).and_return('/admin/posts')
   end
 
   it "does nothing when sending is disabled" do
@@ -131,7 +132,7 @@ describe Localeapp::Rails::Controller, '#send_missing_translations' do
     @controller.send_missing_translations
   end
 
-  it "proceeds when configuration is enabled" do
+  it "proceeds when sending is enabled" do
     Localeapp.configuration.environment_name = 'development'
     Localeapp.sender.should_receive(:post_missing_translations)
     @controller.send_missing_translations
@@ -140,6 +141,13 @@ describe Localeapp::Rails::Controller, '#send_missing_translations' do
   it "rejects blacklisted translations" do
     Localeapp.configuration.environment_name = 'development'
     Localeapp.missing_translations.should_receive(:reject_blacklisted)
+    @controller.send_missing_translations
+  end
+
+  it "does nothing if the current request path is blacklisted" do
+    Localeapp.configuration.environment_name = 'development'
+    Localeapp.configuration.blacklisted_request_paths_pattern = /admin/
+    Localeapp.sender.should_not_receive(:post_missing_translations)
     @controller.send_missing_translations
   end
 end


### PR DESCRIPTION
Gems like active_admin just drop piles and piles of empty translation keys into localeapp. The new "blacklisted keys" feature is nice, but it's often better to just specify a whole route space you don't want to translate. So here's a way to blacklist whole path trees. 

`config.blacklisted_request_paths_pattern = /admin/   #...or any Regex. `
With that line, any page with "admin" in the path will skip sending the missing translations to localeapp.com