### PR TITLE
Allow configuration of SSL version to use in HTTP requests

### DIFF
--- a/lib/localeapp/api_caller.rb
+++ b/lib/localeapp/api_caller.rb
@@ -57,7 +57,8 @@ module Localeapp
           :method => method,
           :headers => headers,
           :timeout => Localeapp.configuration.timeout,
-          :verify_ssl => (Localeapp.configuration.ssl_verify ? OpenSSL::SSL::VERIFY_PEER : false)
+          :verify_ssl => (Localeapp.configuration.ssl_verify ? OpenSSL::SSL::VERIFY_PEER : false),
+          :ssl_version => Localeapp.configuration.ssl_version
         }
         parameters[:ca_file] = Localeapp.configuration.ssl_ca_file if Localeapp.configuration.ssl_ca_file
         if method == :post

--- a/lib/localeapp/configuration.rb
+++ b/lib/localeapp/configuration.rb
@@ -22,6 +22,9 @@ module Localeapp
     # Path to local CA certs bundle
     attr_accessor :ssl_ca_file
 
+    # SSL version to use in requests (defaults to 'SSLv23')
+    attr_accessor :ssl_version
+
     # The port to connect to if it's not the default one
     attr_accessor :port
 
@@ -96,6 +99,7 @@ module Localeapp
         :timeout                    => 60,
         :secure                     => true,
         :ssl_verify                 => false,
+        :ssl_version                => 'SSLv23',
         :sending_environments       => %w(development),
         :reloading_environments     => %w(development),
         :polling_environments       => %w(development),

--- a/spec/localeapp/api_caller_spec.rb
+++ b/spec/localeapp/api_caller_spec.rb
@@ -96,6 +96,20 @@ describe Localeapp::ApiCaller, "#call(object)" do
     end
   end
 
+  context "SSL version" do
+    it "sets the HTTPClient ssl_version to the value given to ssl_version" do
+      Localeapp.configuration.ssl_version = 'SSLv3'
+      RestClient::Request.should_receive(:execute).with(hash_including(:ssl_version => 'SSLv3')).and_return(double('response', :code => 200))
+      @api_caller.call(self)
+    end
+
+    it "doesn't set the HTTPClient ssl_version if it's nil" do
+      Localeapp.configuration.ssl_version = nil
+      RestClient::Request.should_receive(:execute).with(hash_including(:ssl_version => nil)).and_return(double('response', :code => 200))
+      @api_caller.call(self)
+    end
+  end
+
   context "Timeout" do
     it "sets the timeout to the configured timeout" do
       Localeapp.configuration.timeout = 120

--- a/spec/localeapp/configuration_spec.rb
+++ b/spec/localeapp/configuration_spec.rb
@@ -39,6 +39,10 @@ describe Localeapp::Configuration do
     configuration.ssl_verify.should == false
   end
 
+  it "sets ssl_version to 'SSLv23' by default" do
+    configuration.ssl_version.should == 'SSLv23'
+  end
+
   it "allows ssl_verify setting to be overridden" do
     expect { configuration.ssl_verify = true }.to change(configuration, :ssl_verify).to(true)
   end


### PR DESCRIPTION
This patch allows configuration of a specific SSL version to pass on to `RestClient`, and it defaults to `SSLv23` to circumvent POODLE-related issues.
