### PR TITLE
Escape possible HTML in keys before including in a safe string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master
 
+# Version 1.0.1
+
+* Fix error when bundling with Rails >= 4.2 (due to a dependency on i18n < 0.7)
+
 # Version 1.0
 
 * Drop support for Ruby 1.9.2

--- a/lib/localeapp/exception_handler.rb
+++ b/lib/localeapp/exception_handler.rb
@@ -1,16 +1,17 @@
 module Localeapp
   class ExceptionHandler
-    def self.call(exception, locale, key, options)
+    def self.call(exception, locale, key_or_keys, options)
+      keys = Array(key_or_keys).map { |key| ERB::Util.html_escape(key.to_s) }
       Localeapp.log(exception.message)
       # Which exact exception is set up by our i18n shims
       if exception.is_a? Localeapp::I18nMissingTranslationException
-        Localeapp.log("Detected missing translation for key(s) #{key.inspect}")
+        Localeapp.log("Detected missing translation for key(s) #{keys.inspect}")
 
-        [*key].each do |key|
+        keys.each do |key|
           Localeapp.missing_translations.add(locale, key, nil, options || {})
         end
 
-        [locale, key].join(', ')
+        [locale, keys].join('.')
       else
         Localeapp.log('Raising exception')
         raise

--- a/lib/localeapp/exception_handler.rb
+++ b/lib/localeapp/exception_handler.rb
@@ -11,7 +11,7 @@ module Localeapp
           Localeapp.missing_translations.add(locale, key, nil, options || {})
         end
 
-        [locale, keys].join('.')
+        [locale, keys].join(', ')
       else
         Localeapp.log('Raising exception')
         raise

--- a/lib/localeapp/missing_translations.rb
+++ b/lib/localeapp/missing_translations.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Localeapp
   MissingTranslationRecord = Struct.new(:key, :locale, :description, :options) do
     def blacklisted?
@@ -10,7 +12,7 @@ module Localeapp
   end
 
   class MissingTranslations
-    @cached_keys = []
+    @cached_keys = Set.new
 
     class << self
       attr_accessor :cached_keys

--- a/lib/localeapp/version.rb
+++ b/lib/localeapp/version.rb
@@ -1,3 +1,3 @@
 module Localeapp
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   s.name        = "localeapp"
   s.version     = Localeapp::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Christopher Dell", "Chris McGrath"]
-  s.email       = ["chris@tigrish.com", "chris@octopod.info"]
+  s.authors     = ["Christopher Dell", "Chris McGrath", "Michael Baudino"]
+  s.email       = ["chris@tigrish.com", "chris@octopod.info", "michael.baudino@alpine-lab.com"]
   s.homepage    = "http://www.localeapp.com"
   s.summary     = %q{Easy i18n translation management with localeapp.com}
   s.description = %q{Synchronizes i18n translation keys and content with localeapp.com so you don't have to manage translations by hand.}

--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('i18n', '< 0.7')
+  s.add_dependency('i18n')
   s.add_dependency('json')
   s.add_dependency('rest-client')
   s.add_dependency('rack')

--- a/spec/localeapp/exception_handler_spec.rb
+++ b/spec/localeapp/exception_handler_spec.rb
@@ -32,7 +32,11 @@ describe Localeapp::ExceptionHandler, '#call(exception, locale, key, options)' d
 
   it "escapes html tags from keys to prevent xss attacks" do
     expect(Localeapp.missing_translations).to receive(:add).with(:en, '&lt;script&gt;alert(1);&lt;/script&gt;', nil, {})
-    expect(I18n.t('<script>alert(1);</script>')).to eq 'en.&lt;script&gt;alert(1);&lt;/script&gt;'
+    expect(I18n.t('<script>alert(1);</script>')).to eq 'en, &lt;script&gt;alert(1);&lt;/script&gt;'
+  end
+
+  it "joins locale and keys correctly" do
+    expect(I18n.t(['foo', 'bar'])).to eq 'en, foo, bar'
   end
 
   it "handles missing translation exception" do

--- a/spec/localeapp/exception_handler_spec.rb
+++ b/spec/localeapp/exception_handler_spec.rb
@@ -26,8 +26,13 @@ describe Localeapp::ExceptionHandler, '#call(exception, locale, key, options)' d
   end
 
   it "handles when the default is a Symbol that can't be resolved" do
-    expect(Localeapp.missing_translations).to receive(:add).with(:en, :foo, nil, {:default => :bar})
+    expect(Localeapp.missing_translations).to receive(:add).with(:en, 'foo', nil, {:default => :bar})
     I18n.t(:foo, :default => :bar)
+  end
+
+  it "escapes html tags from keys to prevent xss attacks" do
+    expect(Localeapp.missing_translations).to receive(:add).with(:en, '&lt;script&gt;alert(1);&lt;/script&gt;', nil, {})
+    expect(I18n.t('<script>alert(1);</script>')).to eq 'en.&lt;script&gt;alert(1);&lt;/script&gt;'
   end
 
   it "handles missing translation exception" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'support/localeapp_synchronization_data'
 require 'support/i18n/missing_translation'
 require 'logger'
 
+I18n.config.available_locales = :en
+
 def with_configuration(options = {})
   Localeapp.configuration = nil
   Localeapp.configure do |configuration|


### PR DESCRIPTION
When including user-input in `I18n.t`-calls we might get unsafe HTML
content displayed without escaping it properly.


Rails fixed that issue here:
https://github.com/rails/rails/commit/e8d57f361a9982382f75449ec0d65d6c798b9ce2