### PR TITLE
Use a set to lookup missing translations

### DIFF
--- a/lib/localeapp/missing_translations.rb
+++ b/lib/localeapp/missing_translations.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module Localeapp
   MissingTranslationRecord = Struct.new(:key, :locale, :description, :options) do
     def blacklisted?
@@ -10,7 +12,7 @@ module Localeapp
   end
 
   class MissingTranslations
-    @cached_keys = []
+    @cached_keys = Set.new
 
     class << self
       attr_accessor :cached_keys


### PR DESCRIPTION
There's no reason to use an array here `Set` is a much better choice.