### PR TITLE
Fix XSS vulnerability

### DIFF
--- a/lib/localeapp/exception_handler.rb
+++ b/lib/localeapp/exception_handler.rb
@@ -1,16 +1,17 @@
 module Localeapp
   class ExceptionHandler
-    def self.call(exception, locale, key, options)
+    def self.call(exception, locale, key_or_keys, options)
+      keys = Array(key_or_keys).map { |key| ERB::Util.html_escape(key.to_s) }
       Localeapp.log(exception.message)
       # Which exact exception is set up by our i18n shims
       if exception.is_a? Localeapp::I18nMissingTranslationException
-        Localeapp.log("Detected missing translation for key(s) #{key.inspect}")
+        Localeapp.log("Detected missing translation for key(s) #{keys.inspect}")
 
-        [*key].each do |key|
+        keys.each do |key|
           Localeapp.missing_translations.add(locale, key, nil, options || {})
         end
 
-        [locale, key].join(', ')
+        [locale, keys].join(', ')
       else
         Localeapp.log('Raising exception')
         raise

--- a/spec/localeapp/exception_handler_spec.rb
+++ b/spec/localeapp/exception_handler_spec.rb
@@ -26,8 +26,17 @@ describe Localeapp::ExceptionHandler, '#call(exception, locale, key, options)' d
   end
 
   it "handles when the default is a Symbol that can't be resolved" do
-    expect(Localeapp.missing_translations).to receive(:add).with(:en, :foo, nil, {:default => :bar})
+    expect(Localeapp.missing_translations).to receive(:add).with(:en, 'foo', nil, {:default => :bar})
     I18n.t(:foo, :default => :bar)
+  end
+
+  it "escapes html tags from keys to prevent xss attacks" do
+    expect(Localeapp.missing_translations).to receive(:add).with(:en, '&lt;script&gt;alert(1);&lt;/script&gt;', nil, {})
+    expect(I18n.t('<script>alert(1);</script>')).to eq 'en, &lt;script&gt;alert(1);&lt;/script&gt;'
+  end
+
+  it "joins locale and keys correctly" do
+    expect(I18n.t(['foo', 'bar'])).to eq 'en, foo, bar'
   end
 
   it "handles missing translation exception" do


### PR DESCRIPTION
When including user-input in `I18n.t`-calls malicious HTML may be
displayed and cause security issues.

See rails/rails@e8d57f3