### PR TITLE
Adds support for Rails 5 `before_action` controller class methods

### DIFF
--- a/lib/localeapp/rails/controller.rb
+++ b/lib/localeapp/rails/controller.rb
@@ -2,8 +2,13 @@ module Localeapp
   module Rails
     module Controller
       def self.included(base)
-        base.before_filter :handle_translation_updates
-        base.after_filter  :send_missing_translations
+        if base.respond_to? :before_action
+          base.before_action :handle_translation_updates
+          base.after_action :send_missing_translations
+        else
+          base.before_filter :handle_translation_updates
+          base.after_filter  :send_missing_translations
+        end
       end
 
       def handle_translation_updates


### PR DESCRIPTION
Here's that pull request for #186. There's some duplication in the tests, but I'm not sure what facilities Rspec has for cutting that down...I'm a Test::Unit guy myself!