### PR TITLE
Remove rack dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Remove rack dependency
+
 # Version 1.0.2
 
 * Fix a XSS vulnerability where translations keys could contain unescaped HTML (@grekko)

--- a/lib/localeapp/routes.rb
+++ b/lib/localeapp/routes.rb
@@ -1,5 +1,3 @@
-require 'rack/utils'
-
 require "localeapp/routes/base"
 require "localeapp/routes/projects"
 require "localeapp/routes/translations"

--- a/lib/localeapp/routes/base.rb
+++ b/lib/localeapp/routes/base.rb
@@ -21,7 +21,7 @@ module Localeapp
       end
 
       def escape_key(key)
-        Rack::Utils.escape(key).gsub(/\./, '%2E')
+        URI.encode_www_form_component(key).gsub(/\./, '%2E')
       end
     end
   end

--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency('i18n')
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('rest-client', '~> 1.8')
-  s.add_dependency('rack', '~> 1.6')
   s.add_dependency('ya2yaml')
   s.add_dependency('gli')
 

--- a/spec/localeapp/routes_spec.rb
+++ b/spec/localeapp/routes_spec.rb
@@ -98,6 +98,12 @@ describe Localeapp::Routes do
         expect(@routes.remove_url(:key => 'test.key')).to eq("https://test.host/v1/projects/API_KEY/translations/test%2Ekey")
       end
     end
+
+    it "URL encodes the key name" do
+      with_configuration @config do
+        expect(@routes.remove_url key: "some key").to include "some+key"
+      end
+    end
   end
 
   describe "#rename_endpoint(options = {})" do


### PR DESCRIPTION
  We rely on rack for `Rack::Utils.escape`, which itself rely on
`URI.encode_www_form_component`, so we better use this last one
directly, and not depend on rack anymore.
