### PR TITLE
Force `jruby-openssl' dependency to a recent release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 gemspec
 
 platform :jruby do
-  gem 'jruby-openssl'
+  gem 'jruby-openssl', '~> 0.6'
 end

--- a/gemfiles/i18n_0.4.gemfile
+++ b/gemfiles/i18n_0.4.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "i18n", "~> 0.4.0"
 
 platforms :jruby do
-  gem "jruby-openssl"
+  gem "jruby-openssl", "~> 0.6"
 end
 
 gemspec :path => "../"

--- a/gemfiles/i18n_0.5.gemfile
+++ b/gemfiles/i18n_0.5.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "i18n", "~> 0.5.0"
 
 platforms :jruby do
-  gem "jruby-openssl"
+  gem "jruby-openssl", "~> 0.6"
 end
 
 gemspec :path => "../"

--- a/gemfiles/i18n_0.6.gemfile
+++ b/gemfiles/i18n_0.6.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "i18n", "~> 0.6.0"
 
 platforms :jruby do
-  gem "jruby-openssl"
+  gem "jruby-openssl", "~> 0.6"
 end
 
 gemspec :path => "../"

--- a/gemfiles/i18n_0.7.gemfile
+++ b/gemfiles/i18n_0.7.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gem "i18n", "~> 0.7.0"
 
 platforms :jruby do
-  gem "jruby-openssl"
+  gem "jruby-openssl", "~> 0.6"
 end
 
 gemspec :path => "../"


### PR DESCRIPTION
  Older versions are vulnerable to CVE-2009-4123

  http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2009-4123
