### PR TITLE
Remove entry for i18n gem ~> 0.3 in appraisal config

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,3 @@
-appraise "i18n-0.3" do
-  gem "i18n", "~> 0.3.0"
-  gem "activesupport", "~> 2.3.18"
-end
-
 appraise "i18n-0.4" do
   gem "i18n", "~> 0.4.0"
 end


### PR DESCRIPTION
  Support for i18n ~> 0.3 was dropped in 3b8754d

  [ci skip]
