### PR TITLE
write API key to .env if available

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -62,6 +62,9 @@ command :install do |c|
   c.desc "install a skeleton project suitable for Github (warning: README.md will be overwritten)"
   c.switch [:g, 'github']
 
+  c.desc "save API key to .env"
+  c.switch [:d, 'dotenv']
+
   c.action do |global_options, options, args|
     key = args.first
     installer = Localeapp::CLI::Install.new
@@ -69,7 +72,7 @@ command :install do |c|
     installer.config_type = :heroku if options[:heroku]
     installer.config_type = :github if options[:github]
     installer.config_type ||= :rails
-    unless installer.execute(key)
+    unless installer.execute(key, apikey_to_dotenv: options[:dotenv])
       exit_now! "", 1
     end
   end

--- a/bin/localeapp
+++ b/bin/localeapp
@@ -68,6 +68,7 @@ command :install do |c|
     installer.config_type = :standalone if options[:standalone]
     installer.config_type = :heroku if options[:heroku]
     installer.config_type = :github if options[:github]
+    installer.write_dotenv = true if File.exist?('.env')
     installer.config_type ||= :rails
     unless installer.execute(key)
       exit_now! "", 1

--- a/bin/localeapp
+++ b/bin/localeapp
@@ -68,7 +68,6 @@ command :install do |c|
     installer.config_type = :standalone if options[:standalone]
     installer.config_type = :heroku if options[:heroku]
     installer.config_type = :github if options[:github]
-    installer.write_dotenv = true if File.exist?('.env')
     installer.config_type ||= :rails
     unless installer.execute(key)
       exit_now! "", 1

--- a/features/install.feature
+++ b/features/install.feature
@@ -81,12 +81,8 @@ Feature: Installation
   Scenario: Saving api key in .env
     In order to configure my non rails project and have an api key saved in the .env file
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    And an empty file named ".env"
-    When I successfully run `localeapp install --standalone MYAPIKEY`
-    Then the output should contain:
-    """
-    NOTICE: .env detected. Your API key was saved there.
-    """
+    When I successfully run `localeapp install --standalone MYAPIKEY --dotenv`
+    Then the output should contain "NOTICE: API key saved to .env"
     And a file named ".env" should contain "LOCALEAPP_API_KEY=MYAPIKEY"
 
   Scenario: Running install with bad api key

--- a/features/install.feature
+++ b/features/install.feature
@@ -78,6 +78,29 @@ Feature: Installation
       And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
       And the exit status should be 0
 
+  Scenario: Running install with .env
+    In order to configure my non rails project and check my api key is correct
+    Given I have a valid project on localeapp.com with api key "MYAPIKEY"
+    And a file named ".env" with ""
+    When I run `localeapp install --standalone MYAPIKEY`
+    Then the output should contain:
+    """
+    Localeapp Install
+
+    Checking API key: MYAPIKEY
+    Success!
+    Project: Test Project
+    NOTICE: you probably want to add .localeapp to your .gitignore file
+    Writing configuration file to .localeapp/config.rb
+    NOTICE: .env detected. Your API key was saved there.
+    WARNING: please create the locales directory. Your translation data will be stored there.
+    """
+      And help should not be displayed
+      And a file named ".localeapp/config.rb" should exist
+      And a file named ".localeapp/config.rb" should not contain "MYAPIKEY"
+      And a file named ".env" should contain "LOCALEAPP_API_KEY=MYAPIKEY"
+      And the exit status should be 0
+
   Scenario: Running install with bad api key
     In order to configure my project and check my api key is correct
     Given I have a valid project on localeapp.com but an incorrect api key "BADAPIKEY"

--- a/features/install.feature
+++ b/features/install.feature
@@ -78,6 +78,11 @@ Feature: Installation
     And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
     And the exit status should be 0
 
+  Scenario: Not saving api key in .env
+    Given I have a valid project on localeapp.com with api key "MYAPIKEY"
+    When I successfully run `localeapp install --standalone MYAPIKEY`
+    Then a file named ".env" should not contain "LOCALEAPP_API_KEY"
+
   Scenario: Saving api key in .env
     In order to configure my non rails project and have an api key saved in the .env file
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"

--- a/features/install.feature
+++ b/features/install.feature
@@ -81,7 +81,9 @@ Feature: Installation
     Then a file named ".env" should not contain "LOCALEAPP_API_KEY"
 
   Scenario: Saving api key in .env
+
     In order to configure my non rails project and have an api key saved in the .env file
+
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     When I successfully run `localeapp install --standalone MYAPIKEY --dotenv`
     Then the output should contain "NOTICE: API key saved to .env"

--- a/features/install.feature
+++ b/features/install.feature
@@ -13,9 +13,9 @@ Feature: Installation
     Project: Test Project
     Default Locale: en (English)
     """
-    And help should not be displayed
-    And a file named "config/initializers/localeapp.rb" should exist
-    And the exit status should be 0
+      And help should not be displayed
+      And a file named "config/initializers/localeapp.rb" should exist
+      And the exit status should be 0
 
   Scenario: Running standalone install
     In order to configure my non rails project and check my api key is correct
@@ -32,9 +32,9 @@ Feature: Installation
     Writing configuration file to .localeapp/config.rb
     WARNING: please create the locales directory. Your translation data will be stored there.
     """
-    And help should not be displayed
-    And a file named ".localeapp/config.rb" should exist
-    And the exit status should be 0
+      And help should not be displayed
+      And a file named ".localeapp/config.rb" should exist
+      And the exit status should be 0
 
   Scenario: Running github install
     In order to configure my public github project and check my api key is correct
@@ -50,11 +50,11 @@ Feature: Installation
     NOTICE: you probably want to add .localeapp to your .gitignore file
     Writing configuration file to .localeapp/config.rb
     """
-    And help should not be displayed
-    And a file named ".localeapp/config.rb" should exist
-    And a file named ".gitignore" should exist
-    And a file named "README.md" should exist
-    And the exit status should be 0
+      And help should not be displayed
+      And a file named ".localeapp/config.rb" should exist
+      And a file named ".gitignore" should exist
+      And a file named "README.md" should exist
+      And the exit status should be 0
 
   Scenario: Running heroku install with no api key
     In order to configure my project to use localeapp as a heroku addon
@@ -73,10 +73,10 @@ Feature: Installation
     Project: Test Project
     Default Locale: en (English)
     """
-    And help should not be displayed
-    And a file named "config/initializers/localeapp.rb" should exist
-    And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
-    And the exit status should be 0
+      And help should not be displayed
+      And a file named "config/initializers/localeapp.rb" should exist
+      And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
+      And the exit status should be 0
 
   Scenario: Not saving api key in .env
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
@@ -101,6 +101,6 @@ Feature: Installation
     Checking API key: BADAPIKEY
     ERROR: Project not found
     """
-    And help should not be displayed
-    And a file named "config/initializers/localeapp.rb" should not exist
-    And the exit status should not be 0
+      And help should not be displayed
+      And a file named "config/initializers/localeapp.rb" should not exist
+      And the exit status should not be 0

--- a/features/install.feature
+++ b/features/install.feature
@@ -65,9 +65,6 @@ Feature: Installation
     Localeapp Install
 
     Getting API key from heroku config
-    Add the following line to your .env file for Foreman
-    LOCALEAPP_API_KEY=MYAPIKEY
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     Checking API key: MYAPIKEY
     Success!
     Project: Test Project

--- a/features/install.feature
+++ b/features/install.feature
@@ -13,9 +13,9 @@ Feature: Installation
     Project: Test Project
     Default Locale: en (English)
     """
-      And help should not be displayed
-      And a file named "config/initializers/localeapp.rb" should exist
-      And the exit status should be 0
+    And help should not be displayed
+    And a file named "config/initializers/localeapp.rb" should exist
+    And the exit status should be 0
 
   Scenario: Running standalone install
     In order to configure my non rails project and check my api key is correct
@@ -32,9 +32,9 @@ Feature: Installation
     Writing configuration file to .localeapp/config.rb
     WARNING: please create the locales directory. Your translation data will be stored there.
     """
-      And help should not be displayed
-      And a file named ".localeapp/config.rb" should exist
-      And the exit status should be 0
+    And help should not be displayed
+    And a file named ".localeapp/config.rb" should exist
+    And the exit status should be 0
 
   Scenario: Running github install
     In order to configure my public github project and check my api key is correct
@@ -50,11 +50,11 @@ Feature: Installation
     NOTICE: you probably want to add .localeapp to your .gitignore file
     Writing configuration file to .localeapp/config.rb
     """
-      And help should not be displayed
-      And a file named ".localeapp/config.rb" should exist
-      And a file named ".gitignore" should exist
-      And a file named "README.md" should exist
-      And the exit status should be 0
+    And help should not be displayed
+    And a file named ".localeapp/config.rb" should exist
+    And a file named ".gitignore" should exist
+    And a file named "README.md" should exist
+    And the exit status should be 0
 
   Scenario: Running heroku install with no api key
     In order to configure my project to use localeapp as a heroku addon
@@ -73,10 +73,10 @@ Feature: Installation
     Project: Test Project
     Default Locale: en (English)
     """
-      And help should not be displayed
-      And a file named "config/initializers/localeapp.rb" should exist
-      And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
-      And the exit status should be 0
+    And help should not be displayed
+    And a file named "config/initializers/localeapp.rb" should exist
+    And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
+    And the exit status should be 0
 
   Scenario: Running install with .env
     In order to configure my non rails project and check my api key is correct
@@ -95,11 +95,11 @@ Feature: Installation
     NOTICE: .env detected. Your API key was saved there.
     WARNING: please create the locales directory. Your translation data will be stored there.
     """
-      And help should not be displayed
-      And a file named ".localeapp/config.rb" should exist
-      And a file named ".localeapp/config.rb" should not contain "MYAPIKEY"
-      And a file named ".env" should contain "LOCALEAPP_API_KEY=MYAPIKEY"
-      And the exit status should be 0
+    And help should not be displayed
+    And a file named ".localeapp/config.rb" should exist
+    And a file named ".localeapp/config.rb" should not contain "MYAPIKEY"
+    And a file named ".env" should contain "LOCALEAPP_API_KEY=MYAPIKEY"
+    And the exit status should be 0
 
   Scenario: Running install with bad api key
     In order to configure my project and check my api key is correct
@@ -112,6 +112,6 @@ Feature: Installation
     Checking API key: BADAPIKEY
     ERROR: Project not found
     """
-      And help should not be displayed
-      And a file named "config/initializers/localeapp.rb" should not exist
-      And the exit status should not be 0
+    And help should not be displayed
+    And a file named "config/initializers/localeapp.rb" should not exist
+    And the exit status should not be 0

--- a/features/install.feature
+++ b/features/install.feature
@@ -78,28 +78,16 @@ Feature: Installation
     And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
     And the exit status should be 0
 
-  Scenario: Running install with .env
-    In order to configure my non rails project and check my api key is correct
+  Scenario: Saving api key in .env
+    In order to configure my non rails project and have an api key saved in the .env file
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    And a file named ".env" with ""
-    When I run `localeapp install --standalone MYAPIKEY`
+    And an empty file named ".env"
+    When I successfully run `localeapp install --standalone MYAPIKEY`
     Then the output should contain:
     """
-    Localeapp Install
-
-    Checking API key: MYAPIKEY
-    Success!
-    Project: Test Project
-    NOTICE: you probably want to add .localeapp to your .gitignore file
-    Writing configuration file to .localeapp/config.rb
     NOTICE: .env detected. Your API key was saved there.
-    WARNING: please create the locales directory. Your translation data will be stored there.
     """
-    And help should not be displayed
-    And a file named ".localeapp/config.rb" should exist
-    And a file named ".localeapp/config.rb" should not contain "MYAPIKEY"
     And a file named ".env" should contain "LOCALEAPP_API_KEY=MYAPIKEY"
-    And the exit status should be 0
 
   Scenario: Running install with bad api key
     In order to configure my project and check my api key is correct

--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -82,11 +82,11 @@ module Localeapp
         end
 
         def write_apikey_to_dotenv
-          @output.puts "NOTICE: API key saved to .env"
           File.open(".env", "a") do |file|
             file.puts
             file.puts "LOCALEAPP_API_KEY=#{self.key}"
           end
+          @output.puts "NOTICE: API key saved to .env"
         end
 
         def config_api_key_str

--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -83,8 +83,7 @@ module Localeapp
 
         def write_apikey_to_dotenv
           File.open(".env", "a") do |file|
-            file.puts
-            file.puts "LOCALEAPP_API_KEY=#{self.key}"
+            file.write "\nLOCALEAPP_API_KEY=#{self.key}\n"
           end
           @output.puts "NOTICE: API key saved to .env"
         end

--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -83,7 +83,7 @@ module Localeapp
 
         def write_apikey_to_dotenv
           @output.puts "NOTICE: API key saved to .env"
-          File.open('.env', 'a') do |file|
+          File.open(".env", "a") do |file|
             file.puts
             file.puts "LOCALEAPP_API_KEY=#{self.key}"
           end

--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -132,10 +132,6 @@ CONTENT
           if key.nil?
             @output.puts "ERROR: No api key found in heroku config, have you installed the localeapp addon?"
             return
-          elsif not apikey_to_dotenv
-            @output.puts "Add the following line to your .env file for Foreman"
-            @output.puts "LOCALEAPP_API_KEY=#{key}"
-            @output.puts '^' * 80
           end
           super
         end

--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -2,16 +2,14 @@ module Localeapp
   module CLI
     class Install < Command
       attr_accessor :config_type
-      attr_accessor :write_dotenv
 
       def initialize(args = {})
         super
         @config_type = :default
-        @write_dotenv = false
       end
 
       def execute(key = nil)
-        installer("#{config_type.to_s.capitalize}Installer").execute(key, write_dotenv)
+        installer("#{config_type.to_s.capitalize}Installer").execute(key)
       end
 
       def installer(installer_class)
@@ -25,9 +23,9 @@ module Localeapp
           @output = output
         end
 
-        def execute(key = nil, dotenv = false)
+        def execute(key = nil)
           self.key = key
-          self.dotenv = dotenv
+          self.dotenv = File.exist? '.env'
           print_header
           if validate_key
             check_default_locale

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -14,7 +14,7 @@ describe Localeapp::CLI::Install, '.execute(key = nil)' do
 
   it "executes the installer with the given key" do
     installer = double(:installer)
-    expect(installer).to receive(:execute).with(key)
+    expect(installer).to receive(:execute).with(key, false)
     allow(command).to receive(:installer).and_return(installer)
     command.execute(key)
   end

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -14,7 +14,7 @@ describe Localeapp::CLI::Install, '.execute(key = nil)' do
 
   it "executes the installer with the given key" do
     installer = double(:installer)
-    expect(installer).to receive(:execute).with(key, false)
+    expect(installer).to receive(:execute).with(key)
     allow(command).to receive(:installer).and_return(installer)
     command.execute(key)
   end

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -14,7 +14,7 @@ describe Localeapp::CLI::Install, '.execute(key = nil)' do
 
   it "executes the installer with the given key" do
     installer = double(:installer)
-    expect(installer).to receive(:execute).with(key)
+    expect(installer).to receive(:execute).with(key, {})
     allow(command).to receive(:installer).and_return(installer)
     command.execute(key)
   end

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -80,6 +80,45 @@ describe Localeapp::CLI::Install::DefaultInstaller, '#execute(key = nil)' do
       expect(installer.execute(key)).to eq(true)
     end
   end
+
+  context "When saving key to .env is not requested" do
+    let(:execute_options) { {} }
+
+    it 'does not save key to .env' do
+      expect(installer).not_to receive(:write_apikey_to_dotenv)
+      installer.execute(key, execute_options)
+    end
+  end
+
+  context "When saving key to .env is requested" do
+    let(:execute_options) { {:apikey_to_dotenv => true} }
+
+    context "And key validation is successful" do
+      before do
+        allow(installer).to receive(:validate_key).and_return(true)
+        allow(installer).to receive(:check_default_locale)
+        allow(installer).to receive(:set_config_paths)
+        allow(installer).to receive(:write_config_file)
+        allow(installer).to receive(:check_data_directory_exists)
+      end
+
+      it 'saves key to .env' do
+        expect(installer).to receive(:write_apikey_to_dotenv)
+        installer.execute(key, execute_options)
+      end
+    end
+
+    context "And key validation fails" do
+      before :each do
+        allow(installer).to receive(:validate_key).and_return(false)
+      end
+
+      it 'does not save key to .env' do
+        expect(installer).not_to receive(:write_apikey_to_dotenv)
+        installer.execute(key, execute_options)
+      end
+    end
+  end
 end
 
 describe Localeapp::CLI::Install::DefaultInstaller, '#validate_key(key)' do
@@ -168,6 +207,24 @@ CONTENT
     expect(File).to receive(:open).with(config_file_path, 'w+').and_yield(file)
     installer.write_config_file
   end
+
+  context "When saving key to .env is requested" do
+    it "references environment variable in the configuration file" do
+      installer.key = key
+      installer.config_file_path = config_file_path
+      installer.apikey_to_dotenv = true
+      file = double('file')
+      expect(file).to receive(:write).with <<-CONTENT
+require 'localeapp/rails'
+
+Localeapp.configure do |config|
+  config.api_key = ENV['LOCALEAPP_API_KEY']
+end
+CONTENT
+      expect(File).to receive(:open).with(config_file_path, 'w+').and_yield(file)
+      installer.write_config_file
+    end
+  end
 end
 
 describe Localeapp::CLI::Install::DefaultInstaller, '#check_data_directory_exists' do
@@ -189,6 +246,23 @@ describe Localeapp::CLI::Install::DefaultInstaller, '#check_data_directory_exist
     allow(File).to receive(:directory?).with(data_directory).and_return(true)
     installer.check_data_directory_exists
     expect(output.string).to eq('')
+  end
+end
+
+describe Localeapp::CLI::Install::DefaultInstaller, '#write_apikey_to_dotenv' do
+  let(:output) { StringIO.new }
+  let(:key) { 'APIKEY' }
+  let(:installer) { Localeapp::CLI::Install::DefaultInstaller.new(output) }
+
+  it "creates a configuration file containing just the api key" do
+    installer.key = key
+    file = double('file')
+    expect(file).to receive(:write).with <<-CONTENT
+
+LOCALEAPP_API_KEY=APIKEY
+CONTENT
+    expect(File).to receive(:open).with('.env', 'a').and_yield(file)
+    installer.write_apikey_to_dotenv
   end
 end
 


### PR DESCRIPTION
Here is an initial implementation of #191 .

I expect some further modifications will be requested, e.g.

* commandline options to skip .env detection and/or to write it even if it doesn't exist yet
* better integration with the existing `HerokuInstaller`
* checking the .env if it already contains the API key