### PR TITLE
Remove ruby 1.8 workaround

### DIFF
--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -25,9 +25,6 @@ require 'localeapp/cli/remove'
 require 'localeapp/cli/rename'
 require 'localeapp/cli/daemon'
 
-# AUDIT: Will this work on ruby 1.9.x
-$KCODE="UTF8" if RUBY_VERSION < '1.9'
-
 require 'ya2yaml'
 
 module Localeapp


### PR DESCRIPTION
  It was added in b35e835, but we do not support ruby 1.8 anymore.
