### PR TITLE
Remove unused `RedCloth' gem dependency declaration

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.3')
   s.add_development_dependency('yard')
-  s.add_development_dependency('RedCloth', '< 4.3')
   s.add_development_dependency('aruba', '~> 0.8')
   s.add_development_dependency('cucumber', '~> 2.0')
   s.add_development_dependency('fakeweb')


### PR DESCRIPTION
  We introduced this gem in 868811f to manage our documentation in
"textile" format, but we don't have any since 3f9bc02.
