### PR TITLE
Improve travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 before_install:
   - gem install bundler
-  - gem update bundler
 rvm:
   - 1.9.3
   - 2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ dist: trusty
 before_install:
   - gem install bundler
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.10
-  - 2.2.6
   - 2.3.3
+  - 2.2.6
+  - 2.1.10
+  - 2.0.0
+  - 1.9.3
   - jruby
   - jruby-head
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ before_install:
   - gem install bundler
 rvm:
   - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.1
+  - 2.0.0
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
   - jruby
   - jruby-head
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 before_install:
   - gem install bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.0.0
   - 1.9.3
   - jruby
-  - jruby-head
 gemfile:
   - gemfiles/i18n_0.4.gemfile
   - gemfiles/i18n_0.5.gemfile


### PR DESCRIPTION
## Remove unneeded step from travis CI install config

## Configure travis CI to use a non-obsolete env

  As of 20160916, default travis CI env use obsolete releases for jruby:

    jruby-9.0.5.0
    jruby-9.0.4.0
    jruby-9.0.3.0
    jruby-9.0.1.0
    jruby-9.0.0.0.pre2
    jruby-9.0.0.0.pre1
    jruby-9.0.0.0
    jruby-1.7.9-d19
    jruby-1.7.20
    jruby-1.7.19
    jruby-1.7.18
    jruby-1.7.17
    jruby-1.7.11

  jruby stable versions are now 9.1.x, and the last supported release on
1.7 was 1.7.26 (old stable).

  Forcing the usage of their "Ubuntu 14.04" image, which seems more
actively maintained, is done by setting `sudo` to `required` and `dist`
to `trusty`. Note: setting `sudo` to `false` uses "Ubuntu 14.04" image,
but a different version that would bring jruby 1.7.26.

## Fix travis CI build on ruby 2.3

  Travis CI uses RVM to manage ruby versions, but unfortunately it is
not up to date and install old release in most cases (2.4.0rc1 for 2.4,
and 2.3.1p112 for 2.3, etc.).

  It's not possible to update RVM when we use a matrix (multiple ruby
versions, multiple gemfiles), so we have to specify and maintain exact
ruby versions where needed.

## Change build order for MRI rubies on travis CI

  So that we get the most interesting build results faster (recent
rubies).

## Remove travis CI build on `jruby-head`

  We added it in 9f144f3 to workaround RVM bugs in old travis CI
images and be able to test on recent jruby release at the time (jruby
9000.dev).

  However, since we now use more recent travis CI images, specifying
`jruby` is enough to get a stable jruby release (more recent than
specifying `jruby-head` on the old images).
