### PR TITLE
Remove support for ruby 1.9 and ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ rvm:
   - 2.3.3
   - 2.2.6
   - 2.1.10
-  - 2.0.0
-  - 1.9.3
   - jruby
 gemfile:
   - gemfiles/i18n_0.4.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Drop ruby 1.9 and ruby 2.0 support
+
 # Version 2.0.0
 
 * Drop i18n 0.3.x and rails 2.x support

--- a/README.md
+++ b/README.md
@@ -137,10 +137,6 @@ You can invite other developers and translators via localeapp.com.  Developers h
 
 If we find an unknown locale during an import we'll add it to your project. You can also add a new locale to a project via localeapp.com. This will create missing translations for every translation key. You will need to restart any listeners completely to pick up the new locale.
 
-## Syck, Psych, and creating YAML
-
-Since ruby 1.9.3-p0 Psych has been the default YAML engine in Ruby. Psych is based on libyaml and fixes a number of issues with the previous YAML library, Syck. localeapp.com uses 1.9.3 and Psych for all its YAML processing. The localeapp gem will use Psych if it is available but falls back to the ya2yaml library if not. ya2yaml supports UTF-8 (which Syck doesn't handle very well) but it does write YAML differently to Psych so you will notice differences between exporting directly from localeapp.com and doing localeapp pull on the command line unless you're using 1.9.3+ or have installed Psych as a gem.
-
 ## Proxies
 
 If you need to go through a proxy server, you can configure it with:

--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -1,5 +1,6 @@
 require 'i18n'
 require 'i18n/core_ext/hash'
+require 'yaml'
 
 require 'localeapp/i18n_shim'
 require 'localeapp/version'
@@ -24,8 +25,6 @@ require 'localeapp/cli/add'
 require 'localeapp/cli/remove'
 require 'localeapp/cli/rename'
 require 'localeapp/cli/daemon'
-
-require 'ya2yaml'
 
 module Localeapp
   API_VERSION = "1"
@@ -100,11 +99,7 @@ module Localeapp
         raise Localeapp::PotentiallyInsecureYaml if contents =~ /!ruby\//
       end
 
-      if defined?(Psych) && defined?(Psych::VERSION)
-        Psych.load(contents)
-      else
-        normalize_results(YAML.load(contents))
-      end
+      YAML.load(contents)
     end
 
     def load_yaml_file(filename)
@@ -119,22 +114,6 @@ module Localeapp
         return true if results.is_a?(YAML::Yecht::PrivateType) && results.type_id == 'null'
       end
       false
-    end
-
-    def normalize_results(results)
-      if private_null_type(results)
-        nil
-      elsif results.is_a?(Array)
-        results.each_with_index do |value, i|
-          results[i] = normalize_results(value)
-        end
-      elsif results.is_a?(Hash)
-        results.each_pair do |key, value|
-          results[key] = normalize_results(value)
-        end
-      else
-        results
-      end
     end
   end
 end

--- a/lib/localeapp/updater.rb
+++ b/lib/localeapp/updater.rb
@@ -43,11 +43,7 @@ module Localeapp
     private
 
     def generate_yaml(translations)
-      if defined?(Psych) && defined?(Psych::VERSION)
-        Psych.dump(translations, :line_width => -1)[4..-1]
-      else
-        translations.ya2yaml[5..-1]
-      end
+      YAML.dump(translations, :line_width => -1)[4..-1]
     end
 
     def remove_flattened_key!(hash, locale, key)

--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -20,11 +20,12 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = ">= 2.1"
+
   s.add_dependency('mime-types', '~> 2.6')
   s.add_dependency('i18n', '~> 0.4')
   s.add_dependency('json', '~> 1.8')
   s.add_dependency('rest-client', '~> 1.8')
-  s.add_dependency('ya2yaml')
   s.add_dependency('gli')
 
   s.add_development_dependency('rake')

--- a/spec/localeapp/updater_spec.rb
+++ b/spec/localeapp/updater_spec.rb
@@ -122,8 +122,7 @@ describe Localeapp::Updater, ".update(data)" do
     expect(File.exist?(File.join(@yml_dir, 'ja.yml'))).to be false
   end
 
-  if defined?(Psych) && defined?(Psych::VERSION) && Psych::VERSION >= "1.1.0" \
-    && RUBY_PLATFORM != "java"
+  if RUBY_PLATFORM != "java"
     it "doesn't wrap long lines in the output" do
       do_update({
         'translations' => {


### PR DESCRIPTION
  This change is based on original work from @deivid-rodriguez, thanks!
See original version at:

  https://github.com/Locale/localeapp/pull/203
