### PR TITLE
Simplify runtime dependencies in gem specification

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -22,10 +22,9 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.1"
 
-  s.add_dependency('mime-types', '~> 2.6')
   s.add_dependency('i18n', '~> 0.4')
-  s.add_dependency('json', '~> 1.8')
-  s.add_dependency('rest-client', '~> 1.8')
+  s.add_dependency('json')
+  s.add_dependency('rest-client')
   s.add_dependency('gli')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
  In 4fccfba we added version requirements for a few gems, most
probably to workaround build errors on old MRI release. However most
of these requirements are too strict and prevent usage with rails 5 or
`json` and `rest-cient` gems.

* Remove `mime-types` gem dependency requirement: not a direct
  dependency;
* Remove version requirements for `json` gem and `rest-client` gem.
