### PR TITLE
Make dependencies less strict

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -20,10 +20,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('mime-types', '~> 2.6')
+  s.add_dependency('mime-types', '>= 2.6')
   s.add_dependency('i18n', '~> 0.4')
-  s.add_dependency('json', '~> 1.8')
-  s.add_dependency('rest-client', '~> 1.8')
+  s.add_dependency('json', '>= 1.8')
+  s.add_dependency('rest-client', '>= 1.8')
   s.add_dependency('ya2yaml')
   s.add_dependency('gli')
 


### PR DESCRIPTION
So we can use rest-client 2.x, json 2.x and mime-types 3.x