### PR TITLE
Remove config files for tools not used by project

### DIFF
--- a/.autotest
+++ b/.autotest
@@ -1,4 +1,0 @@
-Autotest.add_hook :initialize do |at|
-  at.add_exception %r{^\./\.git/}
-  at.add_exception %r{^\./tmp/}
-end

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use --create ruby-1.9.3@localeapp


### PR DESCRIPTION
  Those are config files for external tools which may have been used by
this gem authors, but they shouldn't be maintained in the gem sources
repository.
