### PR TITLE
Implement `-e' option for `install' subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,1 @@
-pkg/*
-*.gem
-.bundle
-Gemfile.lock
-Gemfile.*.lock
-gemfiles/*.gemfile.lock
-.yardoc/*
-doc/*
-tmp/*
-.ruby-version
-.ruby-gemsets
+/tmp/

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
 --color
--I ./lib
--I ./spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,3 @@
-require 'bundler'
-Bundler::GemHelper.install_tasks
-
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new
 

--- a/bin/localeapp
+++ b/bin/localeapp
@@ -66,14 +66,20 @@ module LocaleappGLIWrapper
     c.desc "install a skeleton project suitable for Github (warning: README.md will be overwritten)"
     c.switch [:g, 'github']
 
+    c.desc "write API key to `#{Localeapp.env_file_path}'"
+    c.switch [:e, "write-env-file"]
+
     c.action do |global_options, options, args|
+      install_opts = {
+        write_env_file: options[:"write-env-file"] ? Localeapp.env_file_path : nil
+      }
       key = args.first
       installer = Localeapp::CLI::Install.new
       installer.config_type = :standalone if options[:standalone]
       installer.config_type = :heroku if options[:heroku]
       installer.config_type = :github if options[:github]
       installer.config_type ||= :rails
-      unless installer.execute(key)
+      unless installer.execute(key, install_opts)
         exit_now! "", 1
       end
     end

--- a/bin/localeapp
+++ b/bin/localeapp
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'gli'
+
 require 'localeapp'
 
 # Don't connect to the net if we're running under cucumber for testing
@@ -18,150 +20,151 @@ if ENV['FAKE_WEB_DURING_CUCUMBER_RUN']
   end
 end
 
-require 'gli'
-gli2 = GLI::VERSION >= '2.0.0'
-
-if gli2
-  include GLI::App
-else
-  include GLI
-end
-
-pre do |global_options, command, options, args|
-  global_options[:k] = if global_options[:k]
-    global_options[:k]
-  elsif ENV['LOCALEAPP_API_KEY']
-    ENV['LOCALEAPP_API_KEY']
-  elsif File.exist?('.env') && IO.read('.env') =~ /^LOCALEAPP_API_KEY=(\w+)$/
-    $1
+module LocaleappGLIWrapper
+  gli2 = GLI::VERSION >= '2.0.0'
+  if gli2
+    include GLI::App
   else
-    nil
+    include GLI
+  end
+  extend self
+
+  pre do |global_options, command, options, args|
+    global_options[:k] = if global_options[:k]
+      global_options[:k]
+    elsif ENV['LOCALEAPP_API_KEY']
+      ENV['LOCALEAPP_API_KEY']
+    elsif File.exist?('.env') && IO.read('.env') =~ /^LOCALEAPP_API_KEY=(\w+)$/
+      $1
+    else
+      nil
+    end
+
+    if Localeapp.has_config_file? || !global_options[:k].nil?
+      true
+    else
+      puts "Could not load config file and no key specified"
+      exit 1
+    end
   end
 
-  if Localeapp.has_config_file? || !global_options[:k].nil?
-    true
+  desc "API Key (for when there is no configuration file)"
+  flag [:k, 'api-key']
+
+  version Localeapp::VERSION
+
+  desc "Creates new configuration files and confirms key works"
+  skips_pre
+  arg_name "<api_key>"
+  command :install do |c|
+    c.desc "install configuration files in .localeapp/"
+    c.switch [:s, 'standalone']
+
+    c.desc "create configuration when using localeapp via a heroku addon (PRE ALPHA)"
+    c.switch [:h, 'heroku']
+
+    c.desc "install a skeleton project suitable for Github (warning: README.md will be overwritten)"
+    c.switch [:g, 'github']
+
+    c.action do |global_options, options, args|
+      key = args.first
+      installer = Localeapp::CLI::Install.new
+      installer.config_type = :standalone if options[:standalone]
+      installer.config_type = :heroku if options[:heroku]
+      installer.config_type = :github if options[:github]
+      installer.config_type ||= :rails
+      unless installer.execute(key)
+        exit_now! "", 1
+      end
+    end
+  end
+
+  desc "Sends the key and content to localeapp.com"
+  arg_name "<key> <locale:content> (<locale:content> ...)"
+  command :add do |c|
+    c.action do |global_options, options, args|
+      key = args.shift
+      if key.nil? || args.size.zero?
+        exit_now! "localeapp add requires a key name and at least one translation", 1
+      else
+        Localeapp::CLI::Add.new(global_options).execute(key, *args)
+      end
+    end
+  end
+
+  desc "removes a key from the project"
+  arg_name "<key>"
+  command :rm do |c|
+    c.action do |global_options, options, args|
+      key = args.shift
+      if key.nil?
+        exit_now! "localeapp rm requires a key name", 1
+      else
+        Localeapp::CLI::Remove.new(global_options).execute(key, *args)
+      end
+    end
+  end
+
+  desc "renames a key in the project"
+  arg_name "<current key name> <new key name>"
+  command :mv do |c|
+    c.action do |global_options, options, args|
+      current_name = args.shift
+      new_name = args.shift
+      if current_name.nil? || new_name.nil?
+        exit_now! "localeapp mv requires a current key name and a new key name", 1
+      else
+        Localeapp::CLI::Rename.new(global_options).execute(current_name, new_name, *args)
+      end
+    end
+  end
+
+  desc "Pulls all translations from localeapp.com"
+  command :pull do |c|
+    c.action do |global_options, options, args|
+      Localeapp::CLI::Pull.new(global_options).execute
+    end
+  end
+
+  desc "Pushes a translation file or directory to localeapp.com"
+  arg_name "<file>"
+  command :push do |c|
+    c.action do |global_options, options, args|
+      if args.empty?
+        exit_now! "localeapp push requires a file or directory to push", 1
+      else
+        path = args.first
+        pusher = Localeapp::CLI::Push.new(global_options)
+        pusher.execute(path)
+      end
+    end
+  end
+
+  desc "Gets any changes since the last poll and updates the yml"
+  command :update do |c|
+    c.action do |global_options, options, args|
+      Localeapp::CLI::Update.new(global_options).execute
+    end
+  end
+
+  desc "Simple daemon (checks for new translations in the background)"
+  command :daemon do |c|
+    c.desc "Interval to wait between checks"
+    c.arg_name 'interval'
+    c.default_value 5
+    c.flag [:i, :interval]
+
+    c.desc "run the daemon in the background"
+    c.switch [:b, 'background']
+
+    c.action do |global_options, options, args|
+      Localeapp::CLI::Daemon.new(global_options).execute(options)
+    end
+  end
+
+  if gli2
+    exit run(ARGV)
   else
-    puts "Could not load config file and no key specified"
-    exit 1
+    exit GLI.run(ARGV)
   end
-end
-
-desc "API Key (for when there is no configuration file)"
-flag [:k, 'api-key']
-
-version Localeapp::VERSION
-
-desc "Creates new configuration files and confirms key works"
-skips_pre
-arg_name "<api_key>"
-command :install do |c|
-  c.desc "install configuration files in .localeapp/"
-  c.switch [:s, 'standalone']
-
-  c.desc "create configuration when using localeapp via a heroku addon (PRE ALPHA)"
-  c.switch [:h, 'heroku']
-
-  c.desc "install a skeleton project suitable for Github (warning: README.md will be overwritten)"
-  c.switch [:g, 'github']
-
-  c.action do |global_options, options, args|
-    key = args.first
-    installer = Localeapp::CLI::Install.new
-    installer.config_type = :standalone if options[:standalone]
-    installer.config_type = :heroku if options[:heroku]
-    installer.config_type = :github if options[:github]
-    installer.config_type ||= :rails
-    unless installer.execute(key)
-      exit_now! "", 1
-    end
-  end
-end
-
-desc "Sends the key and content to localeapp.com"
-arg_name "<key> <locale:content> (<locale:content> ...)"
-command :add do |c|
-  c.action do |global_options, options, args|
-    key = args.shift
-    if key.nil? || args.size.zero?
-      exit_now! "localeapp add requires a key name and at least one translation", 1
-    else
-      Localeapp::CLI::Add.new(global_options).execute(key, *args)
-    end
-  end
-end
-
-desc "removes a key from the project"
-arg_name "<key>"
-command :rm do |c|
-  c.action do |global_options, options, args|
-    key = args.shift
-    if key.nil?
-      exit_now! "localeapp rm requires a key name", 1
-    else
-      Localeapp::CLI::Remove.new(global_options).execute(key, *args)
-    end
-  end
-end
-
-desc "renames a key in the project"
-arg_name "<current key name> <new key name>"
-command :mv do |c|
-  c.action do |global_options, options, args|
-    current_name = args.shift
-    new_name = args.shift
-    if current_name.nil? || new_name.nil?
-      exit_now! "localeapp mv requires a current key name and a new key name", 1
-    else
-      Localeapp::CLI::Rename.new(global_options).execute(current_name, new_name, *args)
-    end
-  end
-end
-
-desc "Pulls all translations from localeapp.com"
-command :pull do |c|
-  c.action do |global_options, options, args|
-    Localeapp::CLI::Pull.new(global_options).execute
-  end
-end
-
-desc "Pushes a translation file or directory to localeapp.com"
-arg_name "<file>"
-command :push do |c|
-  c.action do |global_options, options, args|
-    if args.empty?
-      exit_now! "localeapp push requires a file or directory to push", 1
-    else
-      path = args.first
-      pusher = Localeapp::CLI::Push.new(global_options)
-      pusher.execute(path)
-    end
-  end
-end
-
-desc "Gets any changes since the last poll and updates the yml"
-command :update do |c|
-  c.action do |global_options, options, args|
-    Localeapp::CLI::Update.new(global_options).execute
-  end
-end
-
-desc "Simple daemon (checks for new translations in the background)"
-command :daemon do |c|
-  c.desc "Interval to wait between checks"
-  c.arg_name 'interval'
-  c.default_value 5
-  c.flag [:i, :interval]
-
-  c.desc "run the daemon in the background"
-  c.switch [:b, 'background']
-
-  c.action do |global_options, options, args|
-    Localeapp::CLI::Daemon.new(global_options).execute(options)
-  end
-end
-
-if gli2
-  exit run(ARGV)
-else
-  exit GLI.run(ARGV)
 end

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,8 +1,0 @@
-<%
-rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
-rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags ~@wip"
-%>
-default: <%= std_opts %> features
-wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip

--- a/features/install/write_env_file.feature
+++ b/features/install/write_env_file.feature
@@ -1,0 +1,13 @@
+Feature: Installation with `-e' option
+
+  Scenario: describes `-e' option in the `install' command usage
+    When I successfully run `localeapp help install`
+    Then the output must match /-e.*--\[no-\]write-env-file.*write API key to/i
+
+  Scenario: writes API key to `.env' file when given `-e' option
+    Given I have a valid project on localeapp.com with api key "MYAPIKEY"
+    When I successfully run `localeapp install MYAPIKEY -e`
+    Then the file ".env" must contain exactly:
+      """
+      LOCALEAPP_API_KEY=MYAPIKEY
+      """

--- a/features/step_definitions/filesystem_steps.rb
+++ b/features/step_definitions/filesystem_steps.rb
@@ -1,0 +1,5 @@
+Then /^the file "([^"]+)" must contain exactly:$/ do |path, content|
+  cd ?. do
+    expect(File.read(path)).to eq content + $/
+  end
+end

--- a/features/step_definitions/output_steps.rb
+++ b/features/step_definitions/output_steps.rb
@@ -1,0 +1,10 @@
+Then /^the output must match \/([^\/]+)\/([imx]*)$/ do |pattern, options|
+  regexp = Regexp.new(pattern, options.each_char.inject(0) do |m, e|
+    m | case e
+      when ?i then Regexp::IGNORECASE
+      when ?m then Regexp::MULTILINE
+      when ?x then Regexp::EXTENDED
+    end
+  end)
+  expect(last_command_started.output).to match regexp
+end

--- a/init.rb
+++ b/init.rb
@@ -1,1 +1,0 @@
-require 'localeapp'

--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -29,6 +29,7 @@ require 'localeapp/cli/daemon'
 module Localeapp
   API_VERSION = "1"
   LOG_PREFIX = "** [Localeapp] "
+  ENV_FILE_PATH = ".env".freeze
 
   class LocaleappError < StandardError; end
   class PotentiallyInsecureYaml < LocaleappError; end
@@ -104,6 +105,10 @@ module Localeapp
 
     def load_yaml_file(filename)
       load_yaml(File.read(filename))
+    end
+
+    def env_file_path
+      ENV_FILE_PATH
     end
 
     private

--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -1,37 +1,29 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "localeapp/version"
+require File.expand_path("../lib/localeapp/version", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "localeapp"
   s.version     = Localeapp::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Christopher Dell", "Chris McGrath", "Michael Baudino"]
-  s.email       = ["chris@tigrish.com", "chris@octopod.info", "michael.baudino@alpine-lab.com"]
-  s.homepage    = "http://www.localeapp.com"
+  s.email       = %w[chris@tigrish.com chris@octopod.info michael.baudino@alpine-lab.com]
+  s.homepage    = "http://www.localeapp.com/"
   s.summary     = %q{Easy i18n translation management with localeapp.com}
   s.description = %q{Synchronizes i18n translation keys and content with localeapp.com so you don't have to manage translations by hand.}
-  s.license     = 'MIT'
+  s.license     = "MIT"
 
-  s.rubyforge_project = "localeapp"
-
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.files         = `git ls-files lib`.split $/
+  s.executables   = "localeapp"
 
   s.required_ruby_version = ">= 2.1"
 
-  s.add_dependency('i18n', '~> 0.4')
-  s.add_dependency('json')
-  s.add_dependency('rest-client')
-  s.add_dependency('gli')
+  s.add_dependency "i18n", "~> 0.4"
+  s.add_dependency "json"
+  s.add_dependency "rest-client"
+  s.add_dependency "gli"
 
-  s.add_development_dependency('rake')
-  s.add_development_dependency('rspec', '~> 3.3')
-  s.add_development_dependency('yard')
-  s.add_development_dependency('aruba', '~> 0.8')
-  s.add_development_dependency('cucumber', '~> 2.0')
-  s.add_development_dependency('fakeweb')
-  s.add_development_dependency('appraisal')
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec", "~> 3.3"
+  s.add_development_dependency "aruba", "~> 0.8"
+  s.add_development_dependency "cucumber", "~> 2.0"
+  s.add_development_dependency "fakeweb"
 end

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -26,10 +26,9 @@ describe Localeapp::CLI::Install, "#execute" do
   end
 end
 
-describe Localeapp::CLI::Install::DefaultInstaller, '#execute(key = nil)' do
-  let(:output) { StringIO.new }
-  let(:key) { 'MYAPIKEY' }
-  let(:installer) { Localeapp::CLI::Install::DefaultInstaller.new(output) }
+describe Localeapp::CLI::Install::DefaultInstaller, "#execute" do
+  let(:key)           { "MYAPIKEY" }
+  subject(:installer) { described_class.new StringIO.new }
 
   before do
     allow(installer).to receive(:print_header)

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -30,29 +30,29 @@ describe Localeapp::CLI::Install::DefaultInstaller, "#execute" do
   let(:key)           { "MYAPIKEY" }
   subject(:installer) { described_class.new StringIO.new }
 
-  before do
-    allow(installer).to receive(:print_header)
-    allow(installer).to receive(:validate_key).and_return(false)
-  end
+  context "when key validation fails" do
+    before do
+      allow(installer).to receive(:print_header)
+      allow(installer).to receive(:validate_key).and_return(false)
+    end
 
-  it "prints the header" do
-    expect(installer).to receive(:print_header)
-    installer.execute
-  end
+    it "prints the header" do
+      expect(installer).to receive(:print_header)
+      installer.execute
+    end
 
-  it "validates the key" do
-    expect(installer).to receive(:key=).with(key)
-    expect(installer).to receive(:validate_key)
-    installer.execute(key)
-  end
+    it "validates the key" do
+      expect(installer).to receive(:key=).with(key)
+      expect(installer).to receive(:validate_key)
+      installer.execute(key)
+    end
 
-  context "When key validation fails" do
     it "returns false" do
       expect(installer.execute(key)).to eq(false)
     end
   end
 
-  context "When key validation is successful" do
+  context "when key validation is successful" do
     before do
       allow(installer).to receive(:validate_key).and_return(true)
       allow(installer).to receive(:check_default_locale)

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -1,22 +1,28 @@
 require 'spec_helper'
 require 'localeapp/cli/install'
 
-describe Localeapp::CLI::Install, '.execute(key = nil)' do
-  let(:output) { StringIO.new }
-  let(:key) { 'MYAPIKEY' }
-  let(:command) { Localeapp::CLI::Install.new(:output => output) }
+describe Localeapp::CLI::Install, "#execute" do
+  let(:key)         { "MYAPIKEY" }
+  let(:installer)   { double "installer" }
+  subject(:command) { described_class.new output: output }
 
-  it "creates the installer based on the config type" do
+  it "executes the appropriate installer based on the config type" do
     command.config_type = :heroku
-    expect(command).to receive(:installer).with("HerokuInstaller").and_return(double.as_null_object)
-    command.execute(key)
+    allow(Localeapp::CLI::Install::HerokuInstaller).to receive :new do
+      installer
+    end
+    expect(installer).to receive :execute
+    command.execute key
   end
 
   it "executes the installer with the given key" do
-    installer = double(:installer)
-    expect(installer).to receive(:execute).with(key)
-    allow(command).to receive(:installer).and_return(installer)
-    command.execute(key)
+    allow(Localeapp::CLI::Install::DefaultInstaller).to receive :new do
+      installer
+    end
+    expect(installer)
+      .to receive(:execute)
+      .with key
+    command.execute key
   end
 end
 


### PR DESCRIPTION
This is a work in progress, I'm putting this on hold as I'm not
satisfied with current implementation, especially the usage of `gli`.

I'll comment those issues here.
