### PR TITLE
Run tests with actual dependencies on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - 2.1.10
   - jruby
 gemfile:
+  - Gemfile
   - gemfiles/i18n_0.4.gemfile
   - gemfiles/i18n_0.5.gemfile
   - gemfiles/i18n_0.6.gemfile


### PR DESCRIPTION
  We specified builds only with custom gemfiles, to test against
specific releases of i18n (0.4, 0.5, 0.6 and 0.7). But build with the
standard gemfile is missing, we need to test with i18n actual version
too (0.8 currently).
