### PR TITLE
Fix exit status expectations in user acceptance test

### DIFF
--- a/features/add.feature
+++ b/features/add.feature
@@ -3,7 +3,7 @@ Feature: `add' command
   Scenario: Adds the given translation
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an initializer file
-    When I run `localeapp add foo.baz en:"test en content" es:"test es content"`
+    When I successfully run `localeapp add foo.baz en:"test en content" es:"test es content"`
     Then the output should contain:
     """
     Localeapp Add
@@ -16,7 +16,8 @@ Feature: `add' command
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an initializer file
     When I run `localeapp add`
-    Then the output should contain:
+    Then the exit status must be 1
+    And the output should contain:
     """
     localeapp add requires a key name and at least one translation
     """
@@ -32,7 +33,7 @@ Feature: `add' command
 
   Scenario: Adds the given translation when given the API key on the command line
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    When I run `localeapp -k MYAPIKEY add foo.baz en:"test en content"`
+    When I successfully run `localeapp -k MYAPIKEY add foo.baz en:"test en content"`
     Then the output should contain:
     """
     Localeapp Add
@@ -44,7 +45,7 @@ Feature: `add' command
   Scenario: Adds the given translation when given the API key via environment
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And I have a LOCALEAPP_API_KEY env variable set to "MYAPIKEY"
-    When I run `localeapp add foo.baz en:"test en content"`
+    When I successfully run `localeapp add foo.baz en:"test en content"`
     Then the output should contain:
     """
     Localeapp Add
@@ -56,7 +57,7 @@ Feature: `add' command
   Scenario: Adds the given translation when given the API key in .env file
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And I have a .env file containing the api key "MYAPIKEY"
-    When I run `localeapp add foo.baz en:"test en content"`
+    When I successfully run `localeapp add foo.baz en:"test en content"`
     Then the output should contain:
     """
     Localeapp Add

--- a/features/bad_command.feature
+++ b/features/bad_command.feature
@@ -2,6 +2,7 @@ Feature: Unknown command
 
   Scenario: Reports an error when given unknown command
     When I run `localeapp foo`
+    Then the exit status must be 64
     Then the output should contain:
     """
     error: Unknown command 'foo'

--- a/features/help.feature
+++ b/features/help.feature
@@ -1,7 +1,7 @@
 Feature: `help' command
 
   Scenario: Shows help when given `help' command
-    When I run `localeapp help`
+    When I successfully run `localeapp help`
     Then the output should contain:
     """
     localeapp [global options] command [command options]

--- a/features/install.feature
+++ b/features/install.feature
@@ -2,7 +2,7 @@ Feature: `install' command
 
   Scenario: Installs rails configuration
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    When I run `localeapp install MYAPIKEY`
+    When I successfully run `localeapp install MYAPIKEY`
     Then the output should contain:
     """
     Localeapp Install
@@ -12,13 +12,11 @@ Feature: `install' command
     Project: Test Project
     Default Locale: en (English)
     """
-    And help should not be displayed
     And a file named "config/initializers/localeapp.rb" should exist
-    And the exit status should be 0
 
   Scenario: Installs standalone configuration when given --standalone option
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    When I run `localeapp install --standalone MYAPIKEY`
+    When I successfully run `localeapp install --standalone MYAPIKEY`
     Then the output should contain:
     """
     Localeapp Install
@@ -30,13 +28,11 @@ Feature: `install' command
     Writing configuration file to .localeapp/config.rb
     WARNING: please create the locales directory. Your translation data will be stored there.
     """
-    And help should not be displayed
     And a file named ".localeapp/config.rb" should exist
-    And the exit status should be 0
 
   Scenario: Installs standalone config and other files when given --github option
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
-    When I run `localeapp install --github MYAPIKEY`
+    When I successfully run `localeapp install --github MYAPIKEY`
     Then the output should contain:
     """
     Localeapp Install
@@ -47,15 +43,13 @@ Feature: `install' command
     NOTICE: you probably want to add .localeapp to your .gitignore file
     Writing configuration file to .localeapp/config.rb
     """
-    And help should not be displayed
     And a file named ".localeapp/config.rb" should exist
     And a file named ".gitignore" should exist
     And a file named "README.md" should exist
-    And the exit status should be 0
 
   Scenario: Installs heroku config files when given --heroku option
     Given I have a valid heroku project
-    When I run `localeapp install --heroku`
+    When I successfully run `localeapp install --heroku`
     Then the output should contain:
     """
     Localeapp Install
@@ -69,14 +63,13 @@ Feature: `install' command
     Project: Test Project
     Default Locale: en (English)
     """
-    And help should not be displayed
     And a file named "config/initializers/localeapp.rb" should exist
     And the file "config/initializers/localeapp.rb" should contain "config.api_key = ENV['LOCALEAPP_API_KEY']"
-    And the exit status should be 0
 
   Scenario: Reports an error when given incorrect API key
     Given I have a valid project on localeapp.com but an incorrect api key "BADAPIKEY"
     When I run `localeapp install BADAPIKEY`
+    Then the exit status must be 1
     Then the output should contain:
     """
     Localeapp Install
@@ -84,6 +77,4 @@ Feature: `install' command
     Checking API key: BADAPIKEY
     ERROR: Project not found
     """
-    And help should not be displayed
     And a file named "config/initializers/localeapp.rb" should not exist
-    And the exit status should not be 0

--- a/features/mv.feature
+++ b/features/mv.feature
@@ -3,7 +3,7 @@ Feature: `mv' command
   Scenario: Renames the given translation
     Given I have a valid project on localeapp.com with api key "MYAPIKEY" and the translation key "foo.bar"
     And an initializer file
-    When I run `localeapp mv foo.bar foo.baz`
+    When I successfully run `localeapp mv foo.bar foo.baz`
     Then the output should contain:
     """
     Localeapp mv

--- a/features/pull.feature
+++ b/features/pull.feature
@@ -5,7 +5,7 @@ Feature: `pull' command
     And an initializer file
     And a directory named "config/locales"
     And a directory named "log"
-    When I run `localeapp pull`
+    When I successfully run `localeapp pull`
     Then the output should contain:
     """
     Localeapp Pull
@@ -15,14 +15,14 @@ Feature: `pull' command
     Updating backend:
     Success!
     """
-    And help should not be displayed
     And a file named "config/locales/en.yml" should exist
 
   Scenario: Reports an error when locales directory is missing
     Given I have a translations on localeapp.com for the project with api key "MYAPIKEY"
     And an initializer file
     When I run `localeapp pull`
-    Then the output should contain:
+    Then the exit status must be 1
+    And the output should contain:
     """
     Could not write locale file, please make sure that config/locales exists and is writable
     """
@@ -31,7 +31,7 @@ Feature: `pull' command
     Given I have a translations on localeapp.com for the project with api key "MYAPIKEY"
     And a directory named "config/locales"
     And a directory named "log"
-    When I run `localeapp -k MYAPIKEY pull`
+    When I successfully run `localeapp -k MYAPIKEY pull`
     Then the output should contain:
     """
     Localeapp Pull
@@ -41,5 +41,4 @@ Feature: `pull' command
     Updating backend:
     Success!
     """
-    And help should not be displayed
     And a file named "config/locales/en.yml" should exist

--- a/features/push.feature
+++ b/features/push.feature
@@ -4,7 +4,7 @@ Feature: `push' command
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an initializer file
     And an empty file named "config/locales/en.yml"
-    When I run `localeapp push config/locales/en.yml`
+    When I successfully run `localeapp push config/locales/en.yml`
     Then the output should contain:
     """
     Localeapp Push
@@ -14,14 +14,13 @@ Feature: `push' command
 
     config/locales/en.yml queued for processing.
     """
-    And help should not be displayed
 
   Scenario: Pushes all locales within given directory
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an initializer file
     And an empty file named "config/locales/en.yml"
     And an empty file named "config/locales/es.yml"
-    When I run `localeapp push config/locales`
+    When I successfully run `localeapp push config/locales`
     Then the output should contain:
     """
     Localeapp Push
@@ -36,12 +35,11 @@ Feature: `push' command
 
     config/locales/es.yml queued for processing.
     """
-    And help should not be displayed
 
   Scenario: Pushes a locale file when given the API key on the command line
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an empty file named "config/locales/en.yml"
-    When I run `localeapp -k MYAPIKEY push config/locales/en.yml`
+    When I successfully run `localeapp -k MYAPIKEY push config/locales/en.yml`
     Then the output should contain:
     """
     Localeapp Push
@@ -51,4 +49,3 @@ Feature: `push' command
 
     config/locales/en.yml queued for processing.
     """
-    And help should not be displayed

--- a/features/rm.feature
+++ b/features/rm.feature
@@ -3,7 +3,7 @@ Feature: `rm' command
   Scenario: Removes the given key
     Given I have a valid project on localeapp.com with api key "MYAPIKEY" and the translation key "foo.bar"
     And an initializer file
-    When I run `localeapp rm foo.bar`
+    When I successfully run `localeapp rm foo.bar`
     Then the output should contain:
     """
     Localeapp rm

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -71,15 +71,6 @@ When /^an initializer file$/ do
   }
 end
 
-When /^help should not be displayed$/ do
-  steps %Q{
-    And the output should not contain:
-    """
-    Usage: localeapp COMMAND [options]
-    """
-  }
-end
-
 When /^the timestamp is (\d+) months? old$/ do |months|
   @timestamp = Time.now.to_i - months.to_i * 2592000
   steps %Q{

--- a/features/step_definitions/execution_steps.rb
+++ b/features/step_definitions/execution_steps.rb
@@ -1,0 +1,3 @@
+Then /^the exit status must be (\d+)$/ do |status|
+  expect(last_command_started).to have_exit_status status.to_i
+end

--- a/features/update.feature
+++ b/features/update.feature
@@ -6,9 +6,8 @@ Feature: `update' command
     And the timestamp is 2 months old
     And new translations for the api key "MYAPIKEY" since last fetch with time "60" seconds later
     And a directory named "config/locales"
-    When I run `localeapp update`
+    When I successfully run `localeapp update`
     Then translations should be fetched since last fetch only
-    And help should not be displayed
     And a file named "config/locales/en.yml" should exist
 
   Scenario: Fetches translation when given the API key on the command line
@@ -16,18 +15,16 @@ Feature: `update' command
     And the timestamp is 2 months old
     And new translations for the api key "MYAPIKEY" since last fetch with time "60" seconds later
     And a directory named "config/locales"
-    When I run `localeapp -k MYAPIKEY update`
+    When I successfully run `localeapp -k MYAPIKEY update`
     Then translations should be fetched since last fetch only
-    And help should not be displayed
     And a file named "config/locales/en.yml" should exist
 
   Scenario: Reports an error when timestamp is too old
     Given I have a valid project on localeapp.com with api key "MYAPIKEY"
     And an initializer file
     And the timestamp is 8 months old
-    When I run `localeapp update`
+    When I successfully run `localeapp update`
     Then the output should contain:
     """
     Timestamp is missing or too old
     """
-    And help should not be displayed


### PR DESCRIPTION
* Add missing expectations on localeapp execution return status;
* Remove steps testing that help is not displayed: most probably it was
  a way to ensure this command exist, but we have a dedicated test for
  unknown commands (`bad_command.feature'), and we should generally test
  what known commands do, not what they don't do.

---

Currently depends on #231, #232.
