### PR TITLE
Fix handling of HTTP errors when querying API

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -48,6 +48,17 @@ module LocaleappGLIWrapper
     end
   end
 
+  on_error do |ex|
+    case ex
+    when Localeapp::APIResponseError
+      $stderr.puts "ERROR: #{ex}"
+      exit 70
+      false
+    else
+      true
+    end
+  end
+
   desc "API Key (for when there is no configuration file)"
   flag [:k, 'api-key']
 

--- a/bin/localeapp
+++ b/bin/localeapp
@@ -13,7 +13,7 @@ if ENV['FAKE_WEB_DURING_CUCUMBER_RUN']
   end
   FakeWeb.allow_net_connect = false
   if fake_data_as_json = ENV['FAKE_WEB_FAKES']
-    fakes = JSON.parse(fake_data_as_json)
+    fakes = YAML.load(fake_data_as_json)
     fakes.each do |fake|
       FakeWeb.register_uri fake['method'].to_sym, fake['uri'], { :body => fake['body'], :status => fake['status'] }.merge(fake['headers'])
     end

--- a/features/add.feature
+++ b/features/add.feature
@@ -30,3 +30,9 @@ Feature: `add' command
     """
     localeapp add requires a key name and at least one translation
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    When I run `localeapp -k MYAPIKEY add foo en:bar`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/features/mv.feature
+++ b/features/mv.feature
@@ -11,3 +11,9 @@ Feature: `mv' command
     Renaming key: foo.bar to foo.baz
     Success!
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    When I run `localeapp -k MYAPIKEY mv foo.bar foo.baz`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/features/pull.feature
+++ b/features/pull.feature
@@ -26,3 +26,9 @@ Feature: `pull' command
     """
     Could not write locale file, please make sure that config/locales exists and is writable
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    When I run `localeapp -k MYAPIKEY pull`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/features/push.feature
+++ b/features/push.feature
@@ -35,3 +35,10 @@ Feature: `push' command
 
     config/locales/es.yml queued for processing.
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    And an empty file named "config/locales/en.yml"
+    When I run `localeapp -k MYAPIKEY push config/locales/en.yml`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/features/rm.feature
+++ b/features/rm.feature
@@ -11,3 +11,9 @@ Feature: `rm' command
     Remove key: foo.bar
     Success!
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    When I run `localeapp -k MYAPIKEY rm foo.bar`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/features/step_definitions/cli_steps.rb
+++ b/features/step_definitions/cli_steps.rb
@@ -1,6 +1,12 @@
 require 'net/http'
 require 'time'
 
+Given /^no project exist on localeapp\.com with API key "([^"]+)"$/ do |api_key|
+  add_fake_web_uri :any, /\Ahttps:\/\/api\.localeapp\.com\/.*/,
+    [404, "Not Found"],
+    ""
+end
+
 When /^I have a valid project on localeapp\.com with api key "([^"]*)"$/ do |api_key|
   uri = "https://api.localeapp.com/v1/projects/#{api_key}.json"
   body = valid_project_data.to_json

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ World(LocaleappIntegrationData)
 
 module FakeWebHelper
   def add_fake_web_uri(method, uri, status, body, headers = {})
-    fakes = JSON.parse(aruba.environment['FAKE_WEB_FAKES'] || '[]')
+    fakes = YAML.load(aruba.environment['FAKE_WEB_FAKES'] || '[]')
     fakes << {
       'method' => method,
       'uri' => uri,
@@ -14,7 +14,7 @@ module FakeWebHelper
       'body' => body,
       'headers' => headers
     }
-    set_environment_variable 'FAKE_WEB_FAKES', fakes.to_json
+    set_environment_variable 'FAKE_WEB_FAKES', YAML.dump(fakes)
   end
 end
 World(FakeWebHelper)

--- a/features/update.feature
+++ b/features/update.feature
@@ -19,3 +19,11 @@ Feature: `update' command
     """
     Timestamp is missing or too old
     """
+
+  Scenario: Reports an error when the given API key is incorrect
+    Given no project exist on localeapp.com with API key "MYAPIKEY"
+    And the timestamp is 2 months old
+    And a directory named "config/locales"
+    When I run `localeapp -k MYAPIKEY update`
+    Then the exit status must be 70
+    And the output must match /error.+404/i

--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -34,6 +34,8 @@ module Localeapp
   class LocaleappError < StandardError; end
   class PotentiallyInsecureYaml < LocaleappError; end
   class MissingApiKey < LocaleappError; end
+  class RuntimeError < LocaleappError; end
+  class APIResponseError < RuntimeError; end
 
   class << self
     # An Localeapp configuration object.

--- a/lib/localeapp/cli/pull.rb
+++ b/lib/localeapp/cli/pull.rb
@@ -11,7 +11,7 @@ module Localeapp
         api_call :export,
           :success => :update_backend,
           :failure => :report_failure,
-          :max_connection_attempts => 3
+          :max_connection_attempts => 1
       end
 
       def update_backend(response)
@@ -24,6 +24,7 @@ module Localeapp
 
       def report_failure(response)
         @output.puts "Failed!"
+        fail APIResponseError, "API returned #{response.code} status code"
       end
     end
   end

--- a/lib/localeapp/cli/push.rb
+++ b/lib/localeapp/cli/push.rb
@@ -24,7 +24,7 @@ module Localeapp
             :payload => { :file => file },
             :success => :report_success,
             :failure => :report_failure,
-            :max_connection_attempts => 3
+            :max_connection_attempts => 1
         else
           @output.puts "Could not load file"
         end
@@ -38,6 +38,7 @@ module Localeapp
 
       def report_failure(response)
         @output.puts "Failed!"
+        fail APIResponseError, "API returned #{response.code} status code"
       end
 
       private

--- a/lib/localeapp/cli/remove.rb
+++ b/lib/localeapp/cli/remove.rb
@@ -11,7 +11,7 @@ module Localeapp
           :url_options => { :key => key },
           :success => :report_success,
           :failure => :report_failure,
-          :max_connection_attempts => 3
+          :max_connection_attempts => 1
       end
 
       def report_success(response)
@@ -20,6 +20,7 @@ module Localeapp
 
       def report_failure(response)
         @output.puts "Failed!"
+        fail APIResponseError, "API returned #{response.code} status code"
       end
     end
   end

--- a/lib/localeapp/cli/rename.rb
+++ b/lib/localeapp/cli/rename.rb
@@ -12,7 +12,7 @@ module Localeapp
           :payload => { :new_name => new_name },
           :success => :report_success,
           :failure => :report_failure,
-          :max_connection_attempts => 3
+          :max_connection_attempts => 1
       end
 
       def report_success(response)
@@ -21,6 +21,7 @@ module Localeapp
 
       def report_failure(response)
         @output.puts "Failed!"
+        fail APIResponseError, "API returned #{response.code} status code"
       end
     end
   end

--- a/lib/localeapp/poller.rb
+++ b/lib/localeapp/poller.rb
@@ -52,10 +52,13 @@ module Localeapp
     end
 
     def handle_failure(response)
-      if response.code == 304
+      case response.code
+      when 304
         Localeapp.log_with_time "No new data"
         # Nothing new, update synchronization files
         write_synchronization_data!(current_time, updated_at)
+      when 404
+        fail APIResponseError, "API returned #{response.code} status code"
       end
       @success = false
     end

--- a/lib/localeapp/sender.rb
+++ b/lib/localeapp/sender.rb
@@ -48,6 +48,7 @@ module Localeapp
 
     def handle_missing_translation_failure(response)
        Localeapp.log([translations_url, response.code, @data.inspect].join(' - '))
+       fail APIResponseError, "API returned #{response.code} status code"
     end
   end
 end

--- a/spec/localeapp/cli/pull_spec.rb
+++ b/spec/localeapp/cli/pull_spec.rb
@@ -13,7 +13,7 @@ describe Localeapp::CLI::Pull, "#execute" do
         :export,
         :success => :update_backend,
         :failure => :report_failure,
-        :max_connection_attempts => 3
+        :max_connection_attempts => anything
       )
       @puller.execute
     end

--- a/spec/localeapp/cli/push_spec.rb
+++ b/spec/localeapp/cli/push_spec.rb
@@ -45,7 +45,7 @@ describe Localeapp::CLI::Push, "#push_file(file_path)" do
         :payload => { :file => file },
         :success => :report_success,
         :failure => :report_failure,
-        :max_connection_attempts => 3
+        :max_connection_attempts => anything
       )
       pusher.push_file(file_path)
     end

--- a/spec/localeapp/cli/rename_spec.rb
+++ b/spec/localeapp/cli/rename_spec.rb
@@ -18,7 +18,7 @@ describe Localeapp::CLI::Add, "#execute(current_name, new_name, *rest)" do
         :payload => { :new_name => 'test.new_name' },
         :success => :report_success,
         :failure => :report_failure,
-        :max_connection_attempts => 3
+        :max_connection_attempts => anything
       )
       do_action
     end


### PR DESCRIPTION
Use YAML instead of JSON for fakeweb in UAT
-------------------------------------------

  Using YAML allows us to "mock" HTTP requests with regular expressions
instead of only strings.

---

Fix handling of HTTP errors when querying API
---------------------------------------------

  In UAT we focus on 404 errors, which are triggered when using an
incorrect API key, but those changes should also handle other 4xx errors
correctly.
