### PR TITLE
Stop checking project and app default locale at install

### DIFF
--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -29,7 +29,7 @@ module Localeapp
           self.key = key
           print_header
           if validate_key
-            check_default_locale
+            print_default_locale
             set_config_paths
             @output.puts "Writing configuration file to #{config_file_path}"
             write_config_file
@@ -66,12 +66,13 @@ module Localeapp
           end
         end
 
-        def check_default_locale
+        def print_default_locale
           localeapp_default_code = project_data['default_locale']['code']
-          @output.puts "Default Locale: #{localeapp_default_code} (#{project_data['default_locale']['name']})"
-          if I18n.default_locale.to_s != localeapp_default_code
-            @output.puts "WARNING: I18n.default_locale is #{I18n.default_locale}, change in config/application.rb (Rails 3+)"
-          end
+          @output.puts <<-eoh
+Default Locale: #{localeapp_default_code} (#{project_data['default_locale']['name']})
+Please ensure I18n.default_locale is #{localeapp_default_code} or change it in
+config/application.rb
+          eoh
         end
 
         def set_config_paths
@@ -173,7 +174,7 @@ CONTENT
       end
 
       class StandaloneInstaller < DefaultInstaller
-        def check_default_locale
+        def print_default_locale
           # do nothing standalone
         end
 

--- a/spec/localeapp/cli/install_spec.rb
+++ b/spec/localeapp/cli/install_spec.rb
@@ -65,14 +65,14 @@ describe Localeapp::CLI::Install::DefaultInstaller, "#execute" do
   context "when key validation is successful" do
     before do
       allow(installer).to receive(:validate_key).and_return(true)
-      allow(installer).to receive(:check_default_locale)
+      allow(installer).to receive(:print_default_locale)
       allow(installer).to receive(:set_config_paths)
       allow(installer).to receive(:write_config_file)
       allow(installer).to receive(:check_data_directory_exists)
     end
 
     it "checks the default locale" do
-      expect(installer).to receive(:check_default_locale)
+      expect(installer).to receive(:print_default_locale)
       installer.execute(key)
     end
 
@@ -151,7 +151,7 @@ describe Localeapp::CLI::Install::DefaultInstaller, '#validate_key(key)' do
   end
 end
 
-describe Localeapp::CLI::Install::DefaultInstaller, '#check_default_locale' do
+describe Localeapp::CLI::Install::DefaultInstaller, '#print_default_locale' do
   let(:output) { StringIO.new }
   let(:installer) { Localeapp::CLI::Install::DefaultInstaller.new(output) }
 
@@ -160,15 +160,13 @@ describe Localeapp::CLI::Install::DefaultInstaller, '#check_default_locale' do
   end
 
   it "displays project base locale" do
-    installer.check_default_locale
+    installer.print_default_locale
     expect(output.string).to match(/en \(English\)/)
   end
 
-  it "displays warning if I18n.default_locale doesn't match what's configured on localeapp.com" do
-    allow(I18n).to receive(:default_locale).and_return(:es)
-    installer.check_default_locale
-    expect(output.string)
-      .to match(%r{WARNING: I18n\.default_locale is es, change in config/application\.rb \(Rails 3\+\)})
+  it "warns that I18n.default_locale must match project locale" do
+    installer.print_default_locale
+    expect(output.string).to include "Please ensure I18n.default_locale is en"
   end
 end
 
@@ -264,12 +262,12 @@ CONTENT
     installer.write_config_file
   end
 end
-describe Localeapp::CLI::Install::StandaloneInstaller, '#check_default_locale' do
+describe Localeapp::CLI::Install::StandaloneInstaller, '#print_default_locale' do
   let(:output) { StringIO.new }
   let(:installer) { Localeapp::CLI::Install::StandaloneInstaller.new(output) }
 
   it "does nothing" do
-    installer.check_default_locale
+    installer.print_default_locale
     expect(output.string).to eq('')
   end
 end


### PR DESCRIPTION
  Any project created with a different default locale than `en` will
make the installer output a warning: we cannot know the default locale
configured for the current rails app, we would need to boot it.

  Doing the check at runtime is complex, we would need to rely on a hook
like `Rails.application.config.after_initialize`, and at this time we
don't know the default locale for the Localeapp project. Requesting the
API at this time could prevent the app from booting correctly.
