### PR TITLE
Allow CLI::Pull to target a directory

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -128,9 +128,15 @@ module LocaleappGLIWrapper
   end
 
   desc "Pulls all translations from localeapp.com"
+  arg_name "[target_dir]"
   command :pull do |c|
     c.action do |global_options, options, args|
-      Localeapp::CLI::Pull.new(global_options).execute
+      target_dir = args.shift
+      if !target_dir.nil? && !File.directory?(target_dir)
+        exit_now! "localeapp pull must be targeted at a directory", 1
+      else
+        Localeapp::CLI::Pull.new(global_options).execute(target_dir)
+      end
     end
   end
 

--- a/lib/localeapp/cli/pull.rb
+++ b/lib/localeapp/cli/pull.rb
@@ -3,7 +3,9 @@ module Localeapp
     class Pull < Command
       include ::Localeapp::ApiCall
 
-      def execute
+      def execute(target_dir = nil)
+        @target_dir = target_dir
+
         @output.puts "Localeapp Pull"
         @output.puts ""
 
@@ -17,7 +19,11 @@ module Localeapp
       def update_backend(response)
         @output.puts "Success!"
         @output.puts "Updating backend:"
-        Localeapp.updater.dump(Localeapp.load_yaml(response))
+        if @target_dir.nil?
+          Localeapp.updater.dump(Localeapp.load_yaml(response))
+        else
+          Localeapp.updater.dump(Localeapp.load_yaml(response), @target_dir)
+        end
         @output.puts "Success!"
         Localeapp.poller.write_synchronization_data!(Time.now.to_i, Time.now.to_i)
       end

--- a/lib/localeapp/updater.rb
+++ b/lib/localeapp/updater.rb
@@ -31,9 +31,9 @@ module Localeapp
       end
     end
 
-    def dump(data)
+    def dump(data, target_dir = Localeapp.configuration.translation_data_directory)
       data.each do |locale, translations|
-        filename = File.join(Localeapp.configuration.translation_data_directory, "#{locale}.yml")
+        filename = File.join(target_dir, "#{locale}.yml")
         atomic_write(filename) do |file|
           file.write generate_yaml({locale => translations})
         end

--- a/spec/localeapp/cli/pull_spec.rb
+++ b/spec/localeapp/cli/pull_spec.rb
@@ -35,6 +35,21 @@ describe Localeapp::CLI::Pull, "#update_backend(response)" do
     end
   end
 
+  context "if a target directory is provided" do
+    let(:target_dir) { 'target/dir' }
+    before do
+      @puller.instance_variable_set(:@target_dir, target_dir)
+    end
+
+    it "calls the updater with a target_dir" do
+      with_configuration do
+        allow(Localeapp.poller).to receive(:write_synchronization_data!)
+        expect(Localeapp.updater).to receive(:dump).with(['test data'], target_dir)
+        @puller.update_backend(@test_data)
+      end
+    end
+  end
+
   it "writes the synchronization data" do
     with_configuration do
       allow(Localeapp.updater).to receive(:dump)


### PR DESCRIPTION
Hello! I've found a need to be able to use localeapp without assuming the exact structure of a Rails app. Consequently, it'd be nice to I could target a directory for the translations when running `pull`.

Usage:
```
mkdir -p foo/bar/baz
localeapp pull foo/bar/baz
```

The current usage should remain fine:
```
localeapp pull
```