### PR TITLE
Fix comment on Localeapp::Configuration attributes

### DIFF
--- a/lib/localeapp/configuration.rb
+++ b/lib/localeapp/configuration.rb
@@ -46,7 +46,9 @@ module Localeapp
     # (defaults to 'development')
     attr_accessor :reloading_environments
 
-    # The names of environments where updates aren't pulled
+    # The names of environments where localeapp will poll for translations from
+    # Localeapp API (to check for new translations there) on every page request
+    # to your app's website.
     # (defaults to 'development')
     attr_accessor :polling_environments
 


### PR DESCRIPTION
  Clarify usage of `Localeapp::Configuration#polling_environments`
attribute, after this issue was reported at:

  https://github.com/Locale/localeapp/issues/165

  Thanks @redbar0n for the contribution!

Fixes #165.
