### PR TITLE
Force jruby version 9.1.15.0 on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.3.6
   - 2.2.9
   - 2.1.10
-  - jruby
+  - jruby-9.1.15.0
 gemfile:
   - Gemfile
   - gemfiles/i18n_0.4.gemfile


### PR DESCRIPTION
  For unknown reason, main build will use jruby version 9.1.9.0
successfully, but builds with alternate gem dependencies files attempts
to use 9.1.15.0200 and fail:

    $ rvm use jruby --install --binary --fuzzy
    Unknown ruby string (do not know how to handle): jruby-9.1.15.0200.
    Required jruby-9.1.15.0200 is not installed - installing.
    Unknown ruby string (do not know how to handle): jruby-9.1.15.0200.
    Searching for binary rubies, this might take some time.
    Unknown ruby string (do not know how to handle): jruby-9.1.15.0200.
    Requested binary installation but no rubies are available to download, consider skipping --binary flag.
    Gemset '' does not exist, 'rvm jruby-9.1.15.0200 do rvm gemset create ' first, or append '--create'.

  We force version 9.1.15.0 here, which is latest jruby stable version.
We'll now have to update this from time to time.
