### PR TITLE
Scope keys in ExceptionHandler log messages

### DIFF
--- a/lib/localeapp/exception_handler.rb
+++ b/lib/localeapp/exception_handler.rb
@@ -2,16 +2,17 @@ module Localeapp
   class ExceptionHandler
     def self.call(exception, locale, key_or_keys, options)
       keys = Array(key_or_keys).map { |key| ERB::Util.html_escape(key.to_s) }
+      scoped_keys = keys.map { |key| [options[:scope], key].compact.join(".") }
       Localeapp.log(exception.message)
       # Which exact exception is set up by our i18n shims
       if exception.is_a? Localeapp::I18nMissingTranslationException
-        Localeapp.log("Detected missing translation for key(s) #{keys.inspect}")
+        Localeapp.log("Detected missing translation for key(s) #{scoped_keys.inspect}")
 
         keys.each do |key|
           Localeapp.missing_translations.add(locale, key, nil, options || {})
         end
 
-        [locale, keys].join(', ')
+        [locale, scoped_keys].join(', ')
       else
         Localeapp.log('Raising exception')
         raise

--- a/spec/localeapp/exception_handler_spec.rb
+++ b/spec/localeapp/exception_handler_spec.rb
@@ -46,4 +46,9 @@ describe Localeapp::ExceptionHandler, '#call(exception, locale, key, options)' d
       Localeapp::ExceptionHandler.call(exception, :en, 'foo', {})
     }.to_not raise_error
   end
+
+  it "handles the scope option" do
+    expect(I18n.t('foo.bar', scope: 'scoped')).to eq 'en, scoped.foo.bar'
+    expect(I18n.t(%w{foo.bar foo.baz}, scope: 'scoped')).to eq 'en, scoped.foo.bar, scoped.foo.baz'
+  end
 end


### PR DESCRIPTION
Hello,

I have been trying Localeapp for a few weeks now and I have run into some things I think that can be improved. This first one I'm submitting is this one to make the log messages a bit clearer. I am using WillPaginate and it uses scoped translations. It gave a difference in the output of the log messages:
```ruby
** [Localeapp] translation missing: nl.will_paginate.organization.page_entries_info.single_page_html
** [Localeapp] Detected missing translation for key(s) ["organization.page_entries_info.single_page_html"]
```

As you can see the key registered in the second log message is missing the scope. One might add the wrong translation because of that. I have changed the code to include the scope in the log message. It looks like this now:
```ruby
** [Localeapp] translation missing: nl.will_paginate.organization.page_entries_info.single_page_html
** [Localeapp] Detected missing translation for key(s) ["will_paginate.organization.page_entries_info.single_page_html"]
```

I think this makes it a bit clearer which translation is missing.
