### PR TITLE
Don't add {:raise => false} to options for blacklisted keys

### DIFF
--- a/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
+++ b/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
@@ -14,7 +14,11 @@
 module Localeapp
   module ForceExceptionHandlerInTranslationHelper
     def translate(key, options = {})
-      super(key, {:raise => false}.merge(options))
+      if [options[:scope], key].compact.join(".").match?(Localeapp.configuration.blacklisted_keys_pattern)
+        super(key, options)
+      else
+        super(key, {:raise => false}.merge(options))
+      end
     end
     alias :t :translate
   end


### PR DESCRIPTION
Hello again :wave:,

I experienced a little challenge when using this gem together with [WillPaginate](https://github.com/mislav/will_paginate). In this PR I propose a change to the code that addresses the issue I experienced.

## The challenge
WillPaginate has a [`page_entries_info`](https://github.com/mislav/will_paginate/blob/master/lib/will_paginate/view_helpers.rb#L99-L160) method to add info about the page entries to a view. It first looks for a model-specific translation and when it can not be found it will fall back to a generic translation. It uses [ActionView's translation helper](https://github.com/rails/rails/blob/56832e791f3ec3e586cf049c6408c7a183fdd3a1/actionview/lib/action_view/helpers/translation_helper.rb#L59-L111) that will ensure falling back on to the default translation option. However, Localeapp will ensure that exceptions are not raised [here](https://github.com/Locale/localeapp/blob/master/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb#L17). And since ActionView already removed the default from the options it will never use the default option.

This is expected in a normal case, since Localeapp will create a key in the applications translation repository. But I think it would be better to use the default I18n workflow when the translation is blacklisted.

## My proposed solution
Don't add `{ raise: false }` to the translation options if a key is in the `blacklisted_keys_pattern`. By doing this the translation will follow the default workflow without Localeapp. In my case this fixed the bug I had.

Please let me know if this is a acceptable solution, or if it can better be solved somewhere else in the code.