### PR TITLE
Fix a TypeMismatch error in ExceptionHandler

### DIFF
--- a/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
+++ b/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
@@ -14,7 +14,8 @@
 module Localeapp
   module ForceExceptionHandlerInTranslationHelper
     def translate(key, options = {})
-      if [options[:scope], key].compact.join(".").match?(Localeapp.configuration.blacklisted_keys_pattern)
+      full_key = [options[:scope], key].compact.join(".")
+      if full_key =~ Localeapp.configuration.blacklisted_keys_pattern
         super(key, options)
       else
         super(key, {:raise => false}.merge(options))


### PR DESCRIPTION
This bug happens when blacklisted keys pattern is nil
(_i.e._ when the user has not configured it in its application).

It's due to `String#match?` not handling `nil` as parameter.

We fix it by using `String#=~` instead, which does handle nil as
parameter (and considers it never matching, which is what we want).

This bug was introduced in 4e46de6080f3810be7ea76868f228b4d2d11afaa