### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/localeapp.gemspec
+++ b/localeapp.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.1"
 
   s.add_dependency('i18n', '>= 0.7', '< 2')
-  s.add_dependency('json')
-  s.add_dependency('rest-client')
+  s.add_dependency('json', '>= 1.1.0')
+  s.add_dependency('rest-client', '>= 1.8.0')
   s.add_dependency('gli')
 
   s.add_development_dependency('rake')


### PR DESCRIPTION
To address security issues, we now force `json` and `rest-client`
to versions without known vulnerabilities.

This should avoid the following vulnerabilities:
* OSVDB-101157
* CVE-2015-3448 / OSVDB-117461
* CVE-2013-0269 / OSVDB-101137
* CVE-2015-1820 / OSVDB-119878