### PR TITLE
Use `.localeapprc` as config filename

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -34,7 +34,7 @@ module LocaleappGLIWrapper
       global_options[:k]
     elsif ENV['LOCALEAPP_API_KEY']
       ENV['LOCALEAPP_API_KEY']
-    elsif File.exist?('.env') && IO.read('.env') =~ /^LOCALEAPP_API_KEY=(\w+)$/
+    elsif File.exist?('.localeapprc') && IO.read('.localeapprc') =~ /^LOCALEAPP_API_KEY=(\w+)$/
       $1
     else
       nil


### PR DESCRIPTION
`.env` is a general purpose name and might be taken by other app
specific environment settings. Let's use a name that actually says what
this file is used for.