### PR TITLE
Update Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
-sudo: required
-dist: trusty
+os:
+  - linux
+  - osx
+language: ruby
 before_install:
-  - gem install bundler
+  - gem install bundler -v '< 2'
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
-  - 2.1.10
+  - 2.5
+  - 2.4
+  - 2.3
+  - 2.2
+  - 2.1
   - jruby-9.1.15.0
 gemfile:
   - Gemfile


### PR DESCRIPTION
This PR updates Travis setup to:
* use the more recent and faster Linux virtualized infrastructure (rather than the older containerized infrastructure) by switching Linux testing to Ubuntu Trusty
* enable testing on MacOS X
* use the latest patch version of each Ruby minor version, by declaring only the major and minor versions (RVM will assume the patch version is the latest available) (_e.g._ we use `2.4`, rather than `2.4.3`)
* prevent using Bundler 2, since this version does not support Ruby < 2.3 (while we do support Ruby 2.1 and 2.2)