### PR TITLE
Specify Bundler version to be < 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 before_install:
-  - gem install bundler
+  - gem install bundler -v '< 2'
 rvm:
   - 2.5.0
   - 2.4.3


### PR DESCRIPTION
Prevent using Bundler 2, since this version does not support Ruby < 2.3
(while we do support Ruby 2.1 and 2.2)

Extracted from #264 