### PR TITLE
Bump Travis to use Ubuntu Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-dist: trusty
+dist: xenial
+jdk: openjdk10
 before_install:
   - gem install bundler -v '< 2'
 rvm:


### PR DESCRIPTION
Becuase Trusty will be EOL'd in April 2019.

Extracted from #264 