### PR TITLE
Add OSX to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: required
+os:
+  - linux
+  - osx
 dist: trusty
 before_install:
   - gem install bundler -v '< 2'


### PR DESCRIPTION
Because many developers are working on OSX, we want the test build to
ensure it works there.

Extracted from #264 