### PR TITLE
Fix a crash when .env is a directory

### DIFF
--- a/bin/localeapp
+++ b/bin/localeapp
@@ -34,7 +34,7 @@ module LocaleappGLIWrapper
       global_options[:k]
     elsif ENV['LOCALEAPP_API_KEY']
       ENV['LOCALEAPP_API_KEY']
-    elsif File.exist?('.env') && IO.read('.env') =~ /^LOCALEAPP_API_KEY=(\w+)$/
+    elsif File.file?('.env') && IO.read('.env') =~ /^LOCALEAPP_API_KEY=(\w+)$/
       $1
     else
       nil


### PR DESCRIPTION
As reported in #262, `.env` can sometimes be a directory, in which case, any CLI command fails with `Errno::EISDIR: Is a directory @ io_fread`.

This commit checks that `.env` is a regular file before trying to read it.