### PR TITLE
ruby 3.0 / rails 6.1 incompatibility issue #284

### DIFF
--- a/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
+++ b/lib/localeapp/rails/force_exception_handler_in_translation_helper.rb
@@ -16,9 +16,9 @@ module Localeapp
     def translate(key, options = {})
       full_key = [options[:scope], key].compact.join(".")
       if full_key =~ Localeapp.configuration.blacklisted_keys_pattern
-        super(key, options)
+        super(key, **options)
       else
-        super(key, {:raise => false}.merge(options))
+        super(key, **{:raise => false}.merge(options))
       end
     end
     alias :t :translate


### PR DESCRIPTION
Ruby 3.0 introduced changes described here: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Simplest solution would be to use double splat operator, that was introduced since ruby 2.0. 