### PR TITLE
Support i18n 1.9

### DIFF
--- a/lib/localeapp.rb
+++ b/lib/localeapp.rb
@@ -1,5 +1,4 @@
 require 'i18n'
-require 'i18n/core_ext/hash'
 require 'yaml'
 
 require 'localeapp/i18n_shim'

--- a/lib/localeapp/rails/backport_translation_helper_fix_to_honor_raise_option.rb
+++ b/lib/localeapp/rails/backport_translation_helper_fix_to_honor_raise_option.rb
@@ -49,7 +49,8 @@ module Localeapp::TranslationHelperRails41MonkeyPatch
 
     if html_safe_translation_key?(key)
       html_safe_options = options.dup
-      options.except(*I18n::RESERVED_KEYS).each do |name, value|
+      options.each do |name, value|
+        next if I18n::RESERVED_KEYS.include?(name)
         unless name == :count && value.is_a?(Numeric)
           html_safe_options[name] = ERB::Util.html_escape(value.to_s)
         end


### PR DESCRIPTION
Remove `i18n/core_ext/hash` dependency to support i18n 1.9. Fixes #287.