### PR TITLE
fix install argument parsing

### DIFF
--- a/lib/localeapp/cli/install.rb
+++ b/lib/localeapp/cli/install.rb
@@ -8,7 +8,7 @@ module Localeapp
         @config_type = :default
       end
 
-      def execute(key = nil, **options)
+      def execute(key = nil, options = {})
         installer("#{config_type.to_s.capitalize}Installer")
           .execute key, options
       end
@@ -25,7 +25,7 @@ module Localeapp
           @key_checker  = key_checker
         end
 
-        def execute(key = nil, **options)
+        def execute(key = nil, options = {})
           self.key = key
           print_header
           if validate_key


### PR DESCRIPTION
This fixes an issue that was introduced in 3.0's changes to keyword argument parsing. The issue was mentioned in
https://github.com/Locale/localeapp/issues/284.